### PR TITLE
Develop

### DIFF
--- a/install/setup.sql
+++ b/install/setup.sql
@@ -1066,6 +1066,7 @@ REPLACE INTO `{PREFIX}system_eventnames`
 ('203','OnManagerWelcomeRender','2',''),
 ('204','OnBeforeDocDuplicate','1','Documents'),
 ('205','OnDocDuplicate','1','Documents'),
+('206','OnManagerMainFrameHeaderHTMLBlock','2',''),
 ('999','OnPageUnauthorized','1',''),
 ('1000','OnPageNotFound','1','');
 

--- a/manager/actions/mutate_plugin.dynamic.php
+++ b/manager/actions/mutate_plugin.dynamic.php
@@ -455,7 +455,7 @@ function decode(s){
 				echo "<tr><td colspan='2'><div class='split' style='margin:10px 0;'></div></td></tr>";
 				echo "<tr><td colspan='2'><b>".$row['groupname']."</b></td></tr>";
 		}
-		$evtnames[] = '<input name="sysevents[]" type="checkbox"'.(in_array($row[id],$evts) ? " checked='checked' " : "").'class="inputBox" value="'.$row['id'].'" />'.$row['name'];
+		$evtnames[] = '<input name="sysevents[]" type="checkbox"'.(in_array($row['id'],$evts) ? " checked='checked' " : "").'class="inputBox" value="'.$row['id'].'" />'.$row['name'];
 		if(count($evtnames)==2) echoEventRows($evtnames);
 	}
 	if(count($evtnames)>0) echoEventRows($evtnames);

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -7,11 +7,44 @@
 class DocumentParser {
     var $db; // db object
     var $event, $Event; // event object
-
     var $pluginEvent;
-
     var $config= null;
-    var $rs, $result, $sql, $table_prefix, $debug, $documentIdentifier, $documentMethod, $documentGenerated, $documentContent, $tstart, $minParserPasses, $maxParserPasses, $documentObject, $templateObject, $snippetObjects, $stopOnNotice, $executedQueries, $queryTime, $currentSnippet, $documentName, $aliases, $visitor, $entrypage, $documentListing, $dumpSnippets, $chunkCache, $snippetCache, $contentTypes, $dumpSQL, $queryCode, $virtualDir, $placeholders, $sjscripts, $jscripts, $loadedjscripts, $documentMap;
+    var $rs;
+    var $result;
+    var $sql;
+    var $table_prefix;
+    var $debug;
+    var $documentIdentifier;
+    var $documentMethod;
+    var $documentGenerated;
+    var $documentContent;
+    var $tstart;
+    var $minParserPasses;
+    var $maxParserPasses;
+    var $documentObject;
+    var $templateObject;
+    var $snippetObjects;
+    var $stopOnNotice;
+    var $executedQueries;
+    var $queryTime;
+    var $currentSnippet;
+    var $documentName;
+    var $aliases;
+    var $visitor;
+    var $entrypage;
+    var $documentListing;
+    var $dumpSnippets;
+    var $chunkCache;
+    var $snippetCache;
+    var $contentTypes;
+    var $dumpSQL;
+    var $queryCode;
+    var $virtualDir;
+    var $placeholders;
+    var $sjscripts;
+    var $jscripts;
+    var $loadedjscripts;
+    var $documentMap;
     var $forwards= 3;
 
     // constructor

--- a/manager/includes/header.inc.php
+++ b/manager/includes/header.inc.php
@@ -1,6 +1,10 @@
 <?php
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODx Content Manager instead of accessing this file directly.");
 $mxla = $modx_lang_attribute ? $modx_lang_attribute : 'en';
+
+// invoke OnManagerRegClientStartupHTMLBlock event
+$evtOut = $modx->invokeEvent('OnManagerMainFrameHeaderHTMLBlock');
+$onManagerMainFrameHeaderHTMLBlock = is_array($evtOut) ? '<div id="onManagerMainFrameHeaderHTMLBlock">' . implode('', $evtOut) . '</div>' : '';
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -10,6 +14,9 @@ $mxla = $modx_lang_attribute ? $modx_lang_attribute : 'en';
     <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $modx_manager_charset; ?>" />
     <link rel="stylesheet" type="text/css" href="media/style/<?php echo $manager_theme ? "$manager_theme/":""; ?>style.css" />
 
+    <!-- OnManagerMainFrameHeaderHTMLBlock -->
+    <?php echo $onManagerMainFrameHeaderHTMLBlock; ?>
+    
     <script src="media/script/mootools/mootools.js" type="text/javascript"></script>
     <script src="media/script/mootools/moodx.js" type="text/javascript"></script>
     <script type="text/javascript">


### PR DESCRIPTION
Answering http://bugs.modx.com/issues/2627

Added OnManagerMainFrameHeaderHTMLBlock event: on setup.sql and header.inc.php.
(will be useful for additional JS/CSS scripts for manager's plugin).
Formatting vars typing on document.parser.class.inc.php
Typo on mutate_plugin.dynamic.php

But I could not solve the internal bkmanager.static.php 's JS script into the main frame's HTML header, because the manager pages are parsed directly without any placeholder process beforehand.
