### PR TITLE
Move page generation statistics to own method

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -533,25 +533,17 @@ class DocumentParser {
             }
         }
 
-        $totalTime= ($this->getMicroTime() - $this->tstart);
-        $queryTime= $this->queryTime;
-        $phpTime= $totalTime - $queryTime;
-
-        $queryTime= sprintf("%2.4f s", $queryTime);
-        $totalTime= sprintf("%2.4f s", $totalTime);
-        $phpTime= sprintf("%2.4f s", $phpTime);
-        $source= $this->documentGenerated == 1 ? "database" : "cache";
-        $queries= isset ($this->executedQueries) ? $this->executedQueries : 0;
+        $stats = $this->getTimerStats($this->tstart);
 
         $out =& $this->documentOutput;
         if ($this->dumpSQL) {
             $out .= $this->queryCode;
         }
-        $out= str_replace("[^q^]", $queries, $out);
-        $out= str_replace("[^qt^]", $queryTime, $out);
-        $out= str_replace("[^p^]", $phpTime, $out);
-        $out= str_replace("[^t^]", $totalTime, $out);
-        $out= str_replace("[^s^]", $source, $out);
+        $out= str_replace("[^q^]", $stats['queries'] , $out);
+        $out= str_replace("[^qt^]", $stats['queryTime'] , $out);
+        $out= str_replace("[^p^]", $stats['phpTime'] , $out);
+        $out= str_replace("[^t^]", $stats['totalTime'] , $out);
+        $out= str_replace("[^s^]", $stats['source'] , $out);
         //$this->documentOutput= $out;
 
         // invoke OnWebPagePrerender event
@@ -561,6 +553,22 @@ class DocumentParser {
 
         echo $this->documentOutput;
         ob_end_flush();
+    }
+    
+    function getTimerStats($tstart) {
+    		$stats = array();
+    		
+        $stats['totalTime'] = ($this->getMicroTime() - $tstart);
+        $stats['queryTime'] = $this->queryTime;
+        $stats['phpTime'] = $stats['totalTime'] - $stats['queryTime'];
+
+        $stats['queryTime'] = sprintf("%2.4f s", $stats['queryTime']);
+        $stats['totalTime'] = sprintf("%2.4f s", $stats['totalTime']);
+        $stats['phpTime'] = sprintf("%2.4f s", $stats['phpTime']);
+        $stats['source'] = $this->documentGenerated == 1 ? "database" : "cache";
+        $stats['queries'] = isset ($this->executedQueries) ? $this->executedQueries : 0;
+        
+        return $stats;
     }
 
     function checkPublishStatus() {


### PR DESCRIPTION
A number of times I've wanted to get these statistics in my own code, and early enough to use the data. This minor refactoring moves the page generation statistics code to its own module, allowing snippets and plugins to get the data without having to recreate it.

The statistics can be retrieved at any point, allowing the performance of plugins or snippets to be measured using it (no I can't see that being useful, but anyway). It also allows for more creative output onto the page.
