### PR TITLE
AjaxSearch: Adding charset header in Ajax Mode

### DIFF
--- a/assets/snippets/ajaxSearch/ajaxSearchPopup.php
+++ b/assets/snippets/ajaxSearch/ajaxSearchPopup.php
@@ -6,7 +6,7 @@
 *
 * @author       Coroico - www.modx.wangba.fr
 * @version      1.9.2
-* @date         05/12/2010
+* @date         11/06/2011
 *
 */
 
@@ -55,8 +55,8 @@ if (isset($_POST['search'])) {
 		if ($dcfg['version'] != AS_VERSION) return "<h3>AjaxSearch error: Version number mismatch. Check the content of the default configuration file!</h3>";
         $as = new AjaxSearch();
         $output = $as->run($tstart, $dcfg);
+		header("Content-type: text/html; charset=".$modx->getConfig('modx_charset'));
     }
     echo $output;
 }
-
 ?>


### PR DESCRIPTION
As suggested [here](http://modxcms.com/forums/index.php/topic,62440.msg354393.html#msg354393) a charset header with the modx charset was added, so a server configuration where another charset header is sent by default wouldn't mess up the output.
