### PR TITLE
Solving Bug #7204

### DIFF
--- a/assets/snippets/eform/eform.inc.php
+++ b/assets/snippets/eform/eform.inc.php
@@ -680,8 +680,8 @@ function  eFormParseTemplate($tpl, $isDebug=false ){
 	global $modx,$formats,$optionsName,$_lang,$debugText,$fields,$validFormId;
 	global $efPostBack;
 
-	$formats =""; //clear formats so values don't persist through multiple snippet calls
-	$labels = "";
+	$formats = array(); //clear formats so values don't persist through multiple snippet calls
+	$labels = array();
 
 	$regExpr = "#(<label[^>]*?>)(.*?)</label>#si";;
 	preg_match_all($regExpr,$tpl,$matches);


### PR DESCRIPTION
$formats and $labels are used as array later and with an empty template (i.e. cleaned in eFormOnBeforeFormParse) Bug #7204 appears.
