### PR TITLE
Update cache_sync.class.processor.php

### DIFF
--- a/manager/processors/cache_sync.class.processor.php
+++ b/manager/processors/cache_sync.class.processor.php
@@ -78,7 +78,7 @@ class synccache{
 
         // update publish time file
         $timesArr = array();
-        $result = $modx->db->select('MIN(pub_date) AS minpub', $modx->getFullTableName('site_content'), 'pub_date>'.(time() + $modx->config['server_offset_time']))
+        $result = $modx->db->select('MIN(pub_date) AS minpub', $modx->getFullTableName('site_content'), 'pub_date>'.(time() + $modx->config['server_offset_time']));
         if($minpub = $modx->db->getValue($result)) {
             $timesArr[] = $minpub;
         }


### PR DESCRIPTION
Fixed syntax error in /manager/processors/cache_sync.class.processor.php

Missing semicolon, (parse error: syntax error, unexpected T_IF in manager/processors/cache_sync.class.processor.php on line 82 )
