### PR TITLE
Added parameter for excluding documents with specified ID

### DIFF
--- a/assets/snippets/wayfinder/snippet.wayfinder.php
+++ b/assets/snippets/wayfinder/snippet.wayfinder.php
@@ -60,7 +60,8 @@ $wf->_config = array(
 	'titleOfLinks' => isset($titleOfLinks) ? $titleOfLinks : 'pagetitle',
 	'displayStart' => isset($displayStart) ? $displayStart : FALSE,
 	'entityEncode' => isset($entityEncode) ? $entityEncode : TRUE,
-	'hereId' => isset($hereId) ? intval($hereId) : $modx->documentIdentifier
+	'hereId' => isset($hereId) ? intval($hereId) : $modx->documentIdentifier,
+  'excludeDocsWithTemplate' => isset($excludeDocsWithTemplate) ? $excludeDocsWithTemplate : FALSE
 );
 
 //get user class definitions

--- a/assets/snippets/wayfinder/wayfinder.inc.php
+++ b/assets/snippets/wayfinder/wayfinder.inc.php
@@ -365,6 +365,10 @@ class Wayfinder {
 			if ($this->_config['excludeDocs']) {
 				$menuWhere .= " AND (sc.id NOT IN ({$this->_config['excludeDocs']}))";
 			}
+      // exclude documents with specified template
+      if ($this->_config['excludeDocsWithTemplate']) {
+        $menuWhere .= " AND sc.template NOT IN ({$this->_config['excludeDocsWithTemplate']})";
+      }
 			//add the limit to the query
 			if ($this->_config['limit']) {
 				$sqlLimit = "0, {$this->_config['limit']}";


### PR DESCRIPTION
Useful when you have a lot of subcategories for documents with undefined levels in each one.
For example you don't want to show goods in menu with nested categories.
