### PR TITLE
MariaDB. POSIX collating elements are not supported

### DIFF
--- a/install/setup.sql
+++ b/install/setup.sql
@@ -716,11 +716,11 @@ UPDATE `{PREFIX}system_settings` SET `setting_value` = '0' WHERE `setting_name` 
 
 UPDATE `{PREFIX}site_content` SET `type`='reference', `contentType`='text/html' WHERE `type`='' AND `content` REGEXP '^https?://([-\w\.]+)+(:\d+)?/?';
 
-UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/xml' WHERE `type`='' AND `alias` REGEXP '[.period.](rss|xml)$';
+UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/xml' WHERE `type`='' AND `alias` REGEXP '\.(rss|xml)$';
 
-UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/javascript' WHERE `type`='' AND `alias` REGEXP '[.period.]js$';
+UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/javascript' WHERE `type`='' AND `alias` REGEXP '\.js$';
 
-UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/css' WHERE `type`='' AND `alias` REGEXP '[.period.]css$';
+UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/css' WHERE `type`='' AND `alias` REGEXP '\.css$';
 
 UPDATE `{PREFIX}site_content` SET `type`='document', `contentType`='text/html' WHERE `type`='';
 


### PR DESCRIPTION
 when trying to update modx on MariaDb (hqhost.net)

```
Got error 'POSIX collating elements are not supported at offset 0' from regexp во время выполнения SQL запроса UPDATE `modx_site_content` SET `type`='document', `contentType`='text/xml' WHERE `type`='' AND `alias` REGEXP '[.period.](rss|xml)$'.
Got error 'POSIX collating elements are not supported at offset 0' from regexp во время выполнения SQL запроса UPDATE `modx_site_content` SET `type`='document', `contentType`='text/javascript' WHERE `type`='' AND `alias` REGEXP '[.period.]js$'.
Got error 'POSIX collating elements are not supported at offset 0' from regexp во время выполнения SQL запроса UPDATE `modx_site_content` SET `type`='document', `contentType`='text/css' WHERE `type`='' AND `alias` REGEXP '[.period.]css$'.
```

MariaDB. PCRE Regular Expressions
https://mariadb.com/kb/en/pcre-regular-expressions/
