### PR TITLE
Critical Fix - Fixes Access Permissions error

### DIFF
--- a/manager/processors/user_documents_permissions.class.php
+++ b/manager/processors/user_documents_permissions.class.php
@@ -52,7 +52,7 @@ class udperms{
 			document group is not assigned to a web user group and visa versa.
 		 */
 		$rs = $modx->db->select(
-			'count(sc.id)',
+			'count(DISTINCT sc.id)',
 			"{$tblsc} AS sc 
 				LEFT JOIN {$tbldg} AS dg on dg.document = sc.id 
 				LEFT JOIN {$tbldgn} dgn ON dgn.id = dg.document_group",


### PR DESCRIPTION
We recently discovered on a MODx site which was upgraded that our users could no longer log into MODx Manager and edit content, they were receiving permission denied message. 

We found that the resources had multiple access permissions set and with the current version of MODx could which validates permission the SQL query returns multiple rows due to the join statement as the COUNT(DISTINCT sc.id) was missing, I am unsure to who removed this but it existed in Version 1.0.12 and also the pre release of 1.0.13

Thanks Aaron
