### PR TITLE
Fix PHP Notices from document.parser

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -2809,7 +2809,7 @@ class DocumentParser {
 				for ($i= 0; $i < count($result); $i++){
 					$row = $result[$i];
 					
-					if (!$row['id']){
+					if (!isset($row['id'] or !$row['id']){
 						$output[$row['name']] = $row['value'];
 					}else{
 						$output[$row['name']] = getTVDisplayFormat($row['name'], $row['value'], $row['display'], $row['display_params'], $row['type'], $docid, $sep);
@@ -3008,7 +3008,7 @@ class DocumentParser {
             "mu.id = '{$uid}'"
             );
         if ($row = $this->db->getRow($rs)) {
-            if (!$row["usertype"])
+            if (!isset($row['usertype'] or !$row["usertype"])
                 $row["usertype"]= "manager";
             return $row;
         }
@@ -3028,7 +3028,7 @@ class DocumentParser {
             "wu.id='{$uid}'"
             );
         if ($row = $this->db->getRow($rs)) {
-            if (!$row["usertype"])
+            if (!isset($row['usertype'] or !$row["usertype"])
                 $row["usertype"]= "web";
             return $row;
         }


### PR DESCRIPTION
We're logging PHP Notices in our dev env, and our error.log is filled with PHP Notices from this file.

This fix should eliminate that.
