### PR TITLE
fix kcfinder uploader

### DIFF
--- a/manager/media/browser/mcpuk/js/browser/0bject.js
+++ b/manager/media/browser/mcpuk/js/browser/0bject.js
@@ -22,3 +22,120 @@ var browser = {
     orders: [],
     cms: ""
 };
+var uploader = {
+    uploadQueue : [],
+    uploadInProgress : false,
+    already : false,
+    filesCount : 0,
+    errors : [],
+    boundary : '------multipartdropuploadboundary' + (new Date).getTime(),
+    currentFile : {},
+
+    updateProgress : function (evt) {
+        var progress = evt.lengthComputable
+            ? Math.round((evt.loaded * 100) / evt.total) + '%'
+            : Math.round(evt.loaded / 1024) + " KB";
+        $('#loading').html(browser.label("Uploading file {number} of {count}... {progress}", {
+            number: uploader.filesCount - uploader.uploadQueue.length,
+            count: uploader.filesCount,
+            progress: progress
+        }));
+    },
+
+    processUploadQueue : function() {
+        if (this.uploadInProgress)
+            return false;
+
+        if (this.uploadQueue && this.uploadQueue.length) {
+            var file = this.uploadQueue.shift();
+            this.currentFile = file;
+            $('#loading').html(browser.label("Uploading file {number} of {count}... {progress}", {
+                number: this.filesCount - this.uploadQueue.length,
+                count: this.filesCount,
+                progress: ""
+            }));
+            $('#loading').css('display', 'inline');
+
+            var reader = new FileReader();
+            reader.thisFileName = file.name;
+            reader.thisFileType = file.type;
+            reader.thisFileSize = file.size;
+            reader.thisTargetDir = file.thisTargetDir;
+
+            reader.onload = function(evt) {
+                uploader.uploadInProgress = true;
+                if (!!FileReader.prototype['readAsBinaryString']) {
+                  binary = evt.target.result;
+                } else { //ie10 sucks again
+                  var binary = "";
+                  var bytes = new Uint8Array(evt.target.result);
+                  var length = bytes.byteLength;
+                  for (var i = 0; i < length; i++) 
+                  {
+                    binary += String.fromCharCode(bytes[i]);
+                  }  
+                }
+                var postbody = '--' + uploader.boundary + '\r\nContent-Disposition: form-data; name="upload[]"';
+                if (evt.target.thisFileName)
+                    postbody += '; filename="' + _.utf8encode(evt.target.thisFileName) + '"';
+                postbody += '\r\n';
+                if (evt.target.thisFileSize)
+                    postbody += 'Content-Length: ' + evt.target.thisFileSize + '\r\n';
+                postbody += 'Content-Type: ' + evt.target.thisFileType + '\r\n\r\n' + binary + '\r\n--' + uploader.boundary + '\r\nContent-Disposition: form-data; name="dir"\r\n\r\n' + _.utf8encode(evt.target.thisTargetDir) + '\r\n--' + uploader.boundary + '\r\n--' + uploader.boundary + '--\r\n';
+
+                var xhr = new XMLHttpRequest();
+                xhr.thisFileName = evt.target.thisFileName;
+
+                if (xhr.upload) {
+                    xhr.upload.thisFileName = evt.target.thisFileName;
+                    xhr.upload.addEventListener("progress", uploader.updateProgress, false);
+                }
+                xhr.open('POST', browser.baseGetData('upload'), true);
+                xhr.setRequestHeader('Content-Type', 'multipart/form-data; boundary=' + uploader.boundary);
+                xhr.setRequestHeader('Content-Length', postbody.length);
+
+                xhr.onload = function(e) {
+                    $('#loading').css('display', 'none');
+                    if (browser.dir == reader.thisTargetDir)
+                        browser.fadeFiles();
+                    uploader.uploadInProgress = false;
+                    uploader.already = true;
+                    uploader.processUploadQueue();
+                    if (xhr.responseText.substr(0, 1) != '/')
+                        uploader.errors[uploader.errors.length] = xhr.responseText;
+                }
+
+                xhr.sendAsBinary(postbody);
+            };
+
+            reader.onerror = function(evt) {
+                $('#loading').css('display', 'none');
+                uploader.uploadInProgress = false;
+                uploader.already = true;
+                uploader.processUploadQueue();
+                uploader.errors[uploader.errors.length] = browser.label("Failed to upload {filename}!", {
+                    filename: evt.target.thisFileName
+                });
+            };
+            if (!!FileReader.prototype['readAsBinaryString']) {
+              reader.readAsBinaryString(file);
+            } else {
+              reader.readAsArrayBuffer(file); //ie sucks
+            }
+
+        } else {
+            var loop = setInterval(function() {
+                if (uploader.uploadInProgress) return;
+                clearInterval(loop);
+                if (uploader.currentFile.thisTargetDir == browser.dir)
+                    browser.refresh();
+                uploader.boundary = '------multipartdropuploadboundary' + (new Date).getTime();
+
+                if (uploader.errors.length) {
+                    browser.alert(uploader.errors.join('\n'));
+                    uploader.errors = [];
+                }
+            }, 333);
+        }
+    }
+};


### PR DESCRIPTION
KCFinder currently uses two methods to upload files:
- via form and iframe with 'upload' button;
- via HTML5 File Api with drag-n-drop.
  Both methods allow to upload multiple files, but upload logic is different. Button method uploads and processes all the files at once, while HTML5 method does it one by one. So, the first method is less efficient and brings no success while uploading a lot of high-res images. On the other hand it works everywhere, though multiple files upload is supported only by HTML5 browsers.

After my fixes 'upload' button works via HTML5 (if supported). Form method remains for IE9 and other crappy browsers - but still without multiple files upload.
Also I fixed a bug with HTML5 upload in IE10-11.
