### PR TITLE
Fixed CodeMirror syntax HTML entity highlighting

### DIFF
--- a/assets/plugins/codemirror/codemirror.plugin.php
+++ b/assets/plugins/codemirror/codemirror.plugin.php
@@ -151,10 +151,7 @@ if (('none' == $rte) && $mode) {
 						stream.eat("]");
 						return "modxConfig";
 					}
-					if (stream.match("&")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "=") break;
-						stream.eat("=");
+					if (stream.match(/&([^\s;]+;)?([^\s=]+=)?/)) {
 						return "attribute";
 					}
 					if (stream.match("!]")) {


### PR DESCRIPTION
As I mentioned in [issue #308](https://github.com/modxcms/evolution/issues/308), the current implementation of CodeMirror breaks when HTML entities exist in the editor. Since **&amp;ndash;** is similar enough to **&param=`value`** and the plugin's code only tests for the existence of an ampersand (see removed line 154), I've modified the appropriate conditional to use a regular expression as opposed to a simple text match. Additionally, the `while` loop is no longer necessary since the **Token.match()** method consumes the matched string.

Please see the [CodeMirror mode API documentation](http://codemirror.net/doc/manual.html#modeapi) for more details on the **Token.match()** method.
