### PR TITLE
Fix: weblogin doesn't always clear $_SESSION['webDocgrpNames'] on logout

### DIFF
--- a/assets/snippets/weblogin/weblogin.processor.inc.php
+++ b/assets/snippets/weblogin/weblogin.processor.inc.php
@@ -152,6 +152,7 @@ defined('IN_PARSER_MODE') or die();
             unset($_SESSION['webUsrConfigSet']);
             unset($_SESSION['webUserGroupNames']);
             unset($_SESSION['webDocgroups']);
+            unset($_SESSION['webDocgrpNames']);
         }
         else {
             // Unset all of the session variables.


### PR DESCRIPTION
This bug happens when a web user is logged in and some code has called `$modx->getUserDocGroups(true)` at least once so that the web user's associated resource group names have been cached in `$_SESSION['webDocgrpNames']` and the web user logs out using weblogin.

This commit fixes the bug.