### PR TITLE
Value of properties in GUID on module creation

### DIFF
--- a/manager/processors/save_module.processor.php
+++ b/manager/processors/save_module.processor.php
@@ -66,7 +66,7 @@ switch ($_POST['mode']) {
 				'enable_sharedparams' => $enable_sharedparams,
 				'guid'                => $guid,
 				'modulecode'          => $modulecode,
-				'guid'                => $properties,
+				'properties'          => $properties,
 			), $modx->getFullTableName('site_modules'));
 			
 			// save user group access permissions


### PR DESCRIPTION
This is a bugfix for a little typo that overwrites the guid value with the properties on module creation.
This bug is active since 1.0.13.
Seems to be that creating modules is not an everyday task... :-)