### PR TITLE
For correct work with multibyte URL characters the “basename” function is no longer used.

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -451,7 +451,7 @@ class DocumentParser {
         if ($this->config['use_alias_path'] == 1) {
             $this->virtualDir= dirname($q);
             $this->virtualDir= ($this->virtualDir == '.' ? '' : $this->virtualDir);
-            $q= basename($q);
+            $q = preg_replace('/.*[\/\\\]/', '', $q);
         } else {
             $this->virtualDir= '';
         }
@@ -2311,7 +2311,7 @@ class DocumentParser {
 			$files = glob(MODX_BASE_PATH . 'assets/cache/*');
 			$deletedfiles = array();
 			while ($file = array_shift($files)) {
-				$name = basename($file);
+				$name = preg_replace('/.*[\/\\\]/', '', $file);
 				if (preg_match('/\.pageCache/',$name) && !in_array($name, $deletedfiles)) {
 					$deletedfiles[] = $name;
 					unlink($file);


### PR DESCRIPTION
...ave been updated: the “basename” function is locale aware, so it would be better to avoid it.