### PR TITLE
Maybe missing permission check

### DIFF
--- a/manager/actions/refresh_site.dynamic.php
+++ b/manager/actions/refresh_site.dynamic.php
@@ -1,6 +1,11 @@
 <?php
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
 
+
+if(!$modx->hasPermission('empty_cache')) {
+  $modx->webAlertAndQuit($_lang["error_no_privileges"]);
+}
+
 // (un)publishing of documents, version 2!
 // first, publish document waiting to be published
 $ctime = time();


### PR DESCRIPTION
I'm not sure about the purpose of the field "Empty the site's cache" under "Content management" in the user-roles form. I would think it allows or disallows the user to empty the site's cache by clicking on the menu item "Site -> Clear cache". That doesn't work because there is no permisson check in refresh_site.dynamic.php.
If there is a different purpose, feel free to enlighten me. :-)