### PR TITLE
Workaround for deprecated preg_replace() with /e modifier

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1420,21 +1420,21 @@ class DocumentParser {
                 }
             }
 
-            $in= '!\[\~([0-9]+)\~\]!ise'; // Use preg_replace with /e to make it evaluate PHP
-            $isfriendly= ($this->config['friendly_alias_urls'] == 1 ? 1 : 0);
-            $pref= $this->config['friendly_url_prefix'];
-            $suff= $this->config['friendly_url_suffix'];
-            $thealias= '$aliases[\\1]';
-            $thefolder= '$isfolder[\\1]';
-            if ($this->config['seostrict']=='1'){
-			
-               $found_friendlyurl= "\$this->toAlias(\$this->makeFriendlyURL('$pref','$suff',$thealias,$thefolder,'\\1'))";
-            }else{
-               $found_friendlyurl= "\$this->makeFriendlyURL('$pref','$suff',$thealias,$thefolder,'\\1')";
-            }
-            $not_found_friendlyurl= "\$this->makeFriendlyURL('$pref','$suff','" . '\\1' . "')";
-            $out= "({$isfriendly} && isset({$thealias}) ? {$found_friendlyurl} : {$not_found_friendlyurl})";
-            $documentSource= preg_replace($in, $out, $documentSource);
+            $in= '!\[\~([0-9]+)\~\]!is';
+            $documentSource = preg_replace_callback($in, function($m) use($aliases,$isfolder) {
+                $isfriendly = ($this->config['friendly_alias_urls'] == 1 ? 1 : 0);
+                $pref = $this->config['friendly_url_prefix'];
+                $suff = $this->config['friendly_url_suffix'];
+                $thealias = $aliases[$m[1]];
+                $thefolder = $isfolder[$m[1]];
+                $not_found_friendlyurl = $this->makeFriendlyURL($pref,$suff,$m[1]); 
+                if($this->config['seostrict']=='1'){
+                    $found_friendlyurl =  $this->toAlias($this->makeFriendlyURL($pref,$suff,$thealias,$thefolder,$m[1]));
+                }else {
+                    $found_friendlyurl = $this->makeFriendlyURL($pref,$suff,$thealias,$thefolder,$m[1]);
+                }
+                return ($isfriendly && isset($thealias) ? $found_friendlyurl : $not_found_friendlyurl);
+            } , $documentSource);
 			
         } else {
             $in= '!\[\~([0-9]+)\~\]!is';


### PR DESCRIPTION
Hi there,

I only came across this error, because I wrote a snippet with a function inside, which was not enclosed in `ìf(!function_exists())` and that resulted in a blank page. Otherwise the error "preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead" only shows up in the system log, but the page is rendered as usual.

My server runs on PHP 5.5.29. It works for me, but I didn't test it with all configurations. I refined my original code with the help of http://pastebin.com/2fAGjfkW in [issue 438] (https://github.com/modxcms/evolution/issues/438) which I found after finishing my original workaround...