### PR TITLE
#323 Chunks remember last selected+saved RTE

### DIFF
--- a/assets/plugins/codemirror/codemirror.plugin.php
+++ b/assets/plugins/codemirror/codemirror.plugin.php
@@ -43,6 +43,8 @@ $xrte   = $content['richtext'];
 switch($modx->Event->name) {
     case 'OnTempFormRender'   :
         $object_name = $content['templatename'];
+        $rte   = ($prte ? $prte : 'none');
+        break;
     case 'OnChunkFormRender'  :
         $rte   = isset($which_editor) ? $which_editor : 'none';
         break;

--- a/assets/plugins/codemirror/codemirror.plugin.php
+++ b/assets/plugins/codemirror/codemirror.plugin.php
@@ -15,11 +15,11 @@
  *
  * @see         https://github.com/Mihanik71/CodeMirror-MODx
  */
-global $content;
+global $content, $which_editor;
 $textarea_name = 'post';
 $mode = 'htmlmixed';
 $lang = 'htmlmixed';
-$object_id = md5($evt->name.'-'.$content[id]);
+$object_id = md5($evt->name.'-'.$content['id']);
 /*
  * Default Plugin configuration
  */
@@ -28,9 +28,9 @@ $indentUnit             = (isset($indentUnit)               ? $indentUnit       
 $tabSize                = (isset($tabSize)                  ? $tabSize                  : 4);
 $lineWrapping           = (isset($lineWrapping)             ? $lineWrapping             : false);
 $matchBrackets          = (isset($matchBrackets)            ? $matchBrackets            : false);
-$activeLine           	= (isset($activeLine)             	? $activeLine            	: false);
-$emmet					= (($emmet == 'true')? 	'<script src="'.$_CM_URL.'cm/emmet-compressed.js"></script>' 	: "");
-$search					= (($search == 'true')? '<script src="'.$_CM_URL.'cm/search-compressed.js"></script>' 	: "");
+$activeLine           	= (isset($activeLine)               ? $activeLine            	: false);
+$emmet			= (($emmet == 'true')? 	'<script src="'.$_CM_URL.'cm/emmet-compressed.js"></script>' 	: "");
+$search			= (($search == 'true')? '<script src="'.$_CM_URL.'cm/search-compressed.js"></script>' 	: "");
 /*
  * This plugin is only valid in "text" mode. So check for the current Editor
  */
@@ -44,7 +44,7 @@ switch($modx->Event->name) {
     case 'OnTempFormRender'   :
         $object_name = $content['templatename'];
     case 'OnChunkFormRender'  :
-        $rte   = ($prte ? $prte : 'none');
+        $rte   = isset($which_editor) ? $which_editor : 'none';
         break;
 
     case 'OnDocFormRender'    :

--- a/install/setup.sql
+++ b/install/setup.sql
@@ -163,6 +163,7 @@ CREATE TABLE IF NOT EXISTS `{PREFIX}site_htmlsnippets` (
   `name` varchar(50) NOT NULL default '',
   `description` varchar(255) NOT NULL default 'Chunk',
   `editor_type` integer NOT NULL DEFAULT '0' COMMENT '0-plain text,1-rich text,2-code editor',
+  `editor_name` VARCHAR(50) NOT NULL DEFAULT 'none',
   `category` integer NOT NULL DEFAULT '0' COMMENT 'category id',
   `cache_type`	tinyint(1) NOT NULL default '0' COMMENT 'Cache option',
   `snippet` mediumtext,
@@ -768,6 +769,9 @@ ALTER TABLE `{PREFIX}site_content` ADD COLUMN `alias_visible` INT(2) NOT NULL DE
 #1.1
 ALTER TABLE `{PREFIX}site_templates`
  ADD COLUMN `selectable` TINYINT(4) NOT NULL DEFAULT '1' AFTER `locked`;
+
+ALTER TABLE `{PREFIX}site_htmlsnippets`
+ ADD COLUMN `editor_name` VARCHAR(50) NOT NULL DEFAULT 'none' AFTER `editor_type`;
 
 # ]]upgrade-able
 

--- a/manager/actions/mutate_htmlsnippet.dynamic.php
+++ b/manager/actions/mutate_htmlsnippet.dynamic.php
@@ -47,9 +47,11 @@ if ($modx->manager->hasFormValues()) {
     $modx->manager->loadFormValues();
 }
 
-if (isset($_POST['which_editor']))
-        $which_editor = $_POST['which_editor'];
-else    $which_editor = 'none';
+if (isset($_POST['which_editor'])) {
+    $which_editor = $_POST['which_editor'];
+} else {
+    $which_editor = $content['editor_name'] != 'none' ? $content['editor_name'] : 'none';
+}
 
 $content = array_merge($content, $_POST);
 

--- a/manager/processors/save_htmlsnippet.processor.php
+++ b/manager/processors/save_htmlsnippet.processor.php
@@ -25,6 +25,9 @@ if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
 
 if($name=="") $name = "Untitled chunk";
 
+$editor_type = $_POST['which_editor'] != 'none' ? 1 : 2;
+$editor_name = $_POST['which_editor'] != 'none' ? $_POST['which_editor'] : 'none';
+
 switch ($_POST['mode']) {
     case '77':
 
@@ -51,6 +54,8 @@ switch ($_POST['mode']) {
 				'snippet' => $snippet,
 				'locked' => $locked,
 				'category' => $categoryid,
+                                'editor_type' => $editor_type,
+                                'editor_name' => $editor_name
 			), $modx->getFullTableName('site_htmlsnippets'));
 
 			// invoke OnChunkFormSave event
@@ -99,6 +104,8 @@ switch ($_POST['mode']) {
 				'snippet'     => $snippet,
 				'locked'      => $locked,
 				'category'    => $categoryid,
+                                'editor_type' => $editor_type,
+                                'editor_name' => $editor_name
 			), $modx->getFullTableName('site_htmlsnippets'), "id='{$id}'");
 
 			// invoke OnChunkFormSave event


### PR DESCRIPTION
You can now set a chunk generally using "none" (= use Codemirror) or a specific editor.

For example: With CKEditor4 (2 plugins) you can choose between "CKeditor4" and "CKEditor4 Mini". So its possible to set up a mini-editor with only 6 buttons for editing a chunk like banner-text.

Falls back to plaintext if an editor has been disabled meanwhile. Then after saving chunk, Codemirror is active/default again.