### PR TITLE
Concept on premissions to edit res-type for editors

### DIFF
--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -852,7 +852,7 @@ $page=isset($_REQUEST['page'])?(int)$_REQUEST['page']:'';
 
 <?php
 
-if ($_SESSION['mgrRole'] == 1 || $_REQUEST['a'] != '27' || $_SESSION['mgrInternalKey'] == $content['createdby']) {
+if ($_SESSION['mgrRole'] == 1 || $_SESSION['mgrRole'] == 2 || $_REQUEST['a'] != '27' || $_SESSION['mgrInternalKey'] == $content['createdby']) {
 ?>
             <tr style="height: 24px;"><td width="150"><span class="warning"><?php echo $_lang['resource_type']?></span></td>
                 <td><select name="type" class="inputBox" onchange="documentDirty=true;" style="width:200px">


### PR DESCRIPTION
I need my editors to be able to change ressource-type. They only be allowed to do so on ressources created by their own!
As a temporary fix I added mgrRole 2 to the condition.

Can anybody explain the concept behind that restriction? 
Wouldn't it be worth a setting in the security›role section?