### PR TITLE
Plugin-configuration in JSON-Format

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3824,10 +3824,11 @@ class DocumentParser {
         
         $propertyString = trim($propertyString);
         $token = substr($propertyString,0,1);
-        
+        $property = array();
+
+        // old format
         if ($token=='&') {
             $props= explode('&', $propertyString);
-            $property = array();
             foreach ($props as $prop) {
                 
                 if (strpos($prop, '=')===false) {
@@ -3845,11 +3846,21 @@ class DocumentParser {
                 $property[$key] = $value;
             }
         }
-//      elseif($token=='[' || $token=='{') {
-//          $property = json_decode($propertyString, true);
-//      }
-        else $property = array();
-        
+        // new json-format
+        elseif($token=='{') {
+            $jsonFormat = json_decode($propertyString, true);
+            foreach( $jsonFormat as $key=>$row ) {
+                switch($key) {
+                    case 'pluginConfig':
+                        if(isset($row[0]['events']))   $property['pluginEvents']   = explode(',', $row['events']);
+                        if(isset($row[0]['filePath'])) $property['pluginFilePath'] = $row['filePath'];
+                        break;
+                    default:
+                        $property[$key] = $row[0]['value'];
+                }
+            };
+        }
+
         if(!empty($elementName) && !empty($elementType)){
             $out = $this->invokeEvent('OnParseProperties', array(
                 'element' => $elementName,


### PR DESCRIPTION
- initially converts old configuration-format into new JSON-format
  - "events" and "filePath" get converted automatically
- allows additional descriptions and more
- new "Set automatic"-Button to set Plugin-Events

I think if default-value is set, the acc. config-parameter can easily get a "Set default"-button.

New format:

    {"width":[{"type":"text", "value":"100%", "default":"100%", "label":"Editor-Width", "desc":"Can be set in px or %."}],
     "height":[{"type":"text", "value":"200px", "default":"200px", "label":"Editor-Height", "desc":"Can be set in px or %."}],
     "pluginConfig":[{"events":"OnRichTextEditorRegister,OnRichTextEditorInit,OnInterfaceSettingsRender", "filePath":"tinymce/plugin.tinymce.php"}]
    }

![git1](https://cloud.githubusercontent.com/assets/8569221/13651056/e0aeb43a-e645-11e5-846f-8de8afb9cf60.jpg)
![git2](https://cloud.githubusercontent.com/assets/8569221/13651058/e403c878-e645-11e5-9f07-8e486ca93d66.jpg)
