### PR TITLE
Improved Richtext-TV options-handling, added modxRTEbridge

### DIFF
--- a/assets/lib/class.modxRTEbridge.php
+++ b/assets/lib/class.modxRTEbridge.php
@@ -1,0 +1,904 @@
+<?php
+/**
+ * @author Deesen, yama / updated: 13.03.2016
+ * Issue on Github: https://github.com/modxcms/evolution/issues/498
+ */
+
+class modxRTEbridge
+{
+    public $pluginName = '';                    // Name of plugin - nessecary to retrieve plugin-configuration by connectors
+    public $editorKey = '';                     // Key for config/tpl/settings-files (ckeditor4, tinymce4, ...)
+    public $theme = '';                         // Theme-key (default, simple, mini ... )
+    public $pluginParams = array();             // Params from Modx plugin-configuration
+    public $modxParams = array();               // Holds actual settings coming from Modx- or user-configuration
+    public $bridgeParams = array();             // Holds translation of Modx Configuration-Keys to Editor Configuration-Keys
+    public $themeConfig = array();              // Valid params and defaults for Editor
+    public $tvOptions = array();                // Options set via TV-Option like {"theme":"mini"}
+    public $initOnceArr = array();              // Holds custom HTML-Code to inject into tpl.xxxxxxxxx.init_once.html
+    public $gSettingsCustom = array();          // Holds custom settings to enable setting via Modx- / user-configuration
+    public $gSettingsDefaultValues = array();   // Holds default values for settings
+    public $customPlaceholders = array();       // Holds placeholders to make available in all tpl.xxx.xxx.html
+    public $langArr = array();                  // Holds lang strings
+    public $debug = false;                      // Enable/disable debug messages via HTML-comment
+    public $debugMessages = array();            // Holds all messages - added by    $this->debugMessages[] = 'Message';
+
+    public function __construct($editorKey = NULL, $basePath='', $tvOptions=array())
+    {
+        global $modx, $settings, $usersettings;
+
+        if ($editorKey == NULL) {
+            exit('modxRTEbridge: No editorKey set in plugin-initialization.');
+        };
+
+        // Check right path
+        $file = !empty($basePath) ? $basePath : __FILE__;
+        $current_path = str_replace('\\', '/', dirname($file)) . '/';
+        if (strpos($current_path, MODX_BASE_PATH) !== false) {
+            $path = substr($current_path, strlen(MODX_BASE_PATH));
+            $basePath = MODX_BASE_PATH . $path;
+            $baseUrl = MODX_BASE_URL . $path;
+        } else exit('modxRTEbridge: Path-Error');
+
+        // Init language before bridge so bridge can alter translations via $this->setLang()
+        $this->initLang($basePath);
+
+        // Get modxRTEbridge-config
+        if (is_readable("{$basePath}gsettings/bridge.{$editorKey}.inc.php")) {
+            include("{$basePath}gsettings/bridge.{$editorKey}.inc.php");
+            $this->bridgeParams = isset($bridgeParams) ? $bridgeParams : array();
+            $this->gSettingsCustom = isset($gSettingsCustom) ? $gSettingsCustom : array();
+            $this->gSettingsDefaultValues = isset($gSettingsDefaultValues) ? $gSettingsDefaultValues : array();
+        } else exit("modxRTEbridge: {$basePath}gsettings/bridge.{$editorKey}.inc.php not found");
+
+        // Determine settings from Modx
+        $mgrAction = isset($modx->manager->action) ? $modx->manager->action : 11;
+        switch ($mgrAction) {
+            // Create empty array()
+            case 11:    // Create new user
+                $editorConfig = array();
+                break;
+            // Get user-config
+            case 12:    // Edit user
+            case 119:   // Purge plugin processor
+                $editorConfig = $usersettings;
+                if (!empty($usersettings[$this->editorKey . '_theme'])) {
+                    $usersettings[$this->editorKey . '_theme'] = $settings[$this->editorKey . '_theme'];
+                }
+                break;
+            // Get Modx-config
+            case 17:    // Modx-configuration
+            default:
+                $editorConfig = $settings;
+                break;
+        };
+
+        // Modx default WYSIWYG-params
+        $modxParamsArr = array(
+            'theme', 'skin', 'entermode', 'element_format', 'schema', 'css_selectors',
+            'custom_plugins', 'custom_buttons1', 'custom_buttons2', 'custom_buttons3', 'custom_buttons4',
+            'template_docs', 'template_chunks'
+        );
+
+        // Add custom settings from bridge
+        foreach ($this->gSettingsCustom as $name => $x) {
+            if (!in_array($name, $modxParamsArr)) $modxParamsArr[] = $name;
+        };
+
+        // Take over editor-configuration from Modx
+        foreach ($modxParamsArr as $p) {
+            $value = isset($editorConfig[$editorKey . '_' . $p]) ? $editorConfig[$editorKey . '_' . $p] : NULL;
+            $value = $value === NULL && isset($this->gSettingsDefaultValues[$p]) ? $this->gSettingsDefaultValues[$p] : $value;
+
+            $this->modxParams[$p] = $value;
+        };
+
+        // Set TV-options
+        $this->tvOptions = $tvOptions;
+
+        // Get/set pluginParams
+        $this->editorKey = $editorKey;
+        $this->theme = isset($this->modxParams['theme']) ? $this->modxParams['theme'] : 'base';
+        $this->pluginParams = isset($modx->event->params) ? $modx->event->params : array();
+        $this->pluginParams['pluginName'] = $modx->event->activePlugin;
+        $this->pluginParams['editorLabel'] = isset($editorLabel) ? $editorLabel : 'No editorLabel set for "' . $editorKey . '"';
+        $this->pluginParams['editorVersion'] = isset($editorVersion) ? $editorVersion : 'No editorVersion set';
+        $this->pluginParams['editorLogo'] = isset($editorLogo) ? $editorLogo : '';
+        $this->pluginParams['skinsDirectory'] = isset($skinsDirectory) && !empty($skinsDirectory) ? trim($skinsDirectory, "/") . "/" : '';
+        $this->pluginParams['base_path'] = $basePath;
+        $this->pluginParams['base_url'] = $baseUrl;
+    }
+
+    // Function to set editor-parameters
+    // $value = NULL deletes key completely from editor-config
+    public function set($key, $value, $type=false, $emptyAllowed=false)
+    {
+        if ($value === NULL) {
+            $this->themeConfig[$key] = NULL;    // Delete Parameter completely from JS-initialization
+        } else {
+            if(!isset($this->themeConfig[$key])) $this->themeConfig[$key] = array();
+            $this->themeConfig[$key]['value']   = $value;
+            $this->themeConfig[$key]['default'] = !isset($this->themeConfig[$key]['default']) ? $value : $this->themeConfig[$key]['default'];
+            $this->themeConfig[$key]['type']    = $type == false ? 'string' : $type;
+            $this->themeConfig[$key]['empty']   = $emptyAllowed;
+        }
+    }
+
+    // Function to append string to existing parameters
+    public function appendSet($key, $value, $separator = ',')
+    {
+        if ($value === '') { return; };
+
+        if (isset($this->themeConfig[$key])) {
+            $this->themeConfig[$key]['value'] .= $this->themeConfig[$key]['value'] != '' ? $separator.$value : $value;
+        };
+    }
+
+    // Function to force editor-setting via plugin-code
+    // $value = NULL deletes key completely from editor-config
+    public function force($key, $value)
+    {
+        if ($value === NULL) {
+            $this->themeConfig[$key] = NULL;  // Delete Parameter completely from JS-initialization
+        } else {
+            if(!isset($this->themeConfig[$key])) $this->themeConfig[$key] = array();
+            $this->themeConfig[$key]['force'] = $value;
+        }
+    }
+
+    // Function to append custom HTML-Code to tpl.editor.init_once.html
+    public function appendInitOnce($str)
+    {
+        if (!in_array($str, $this->initOnceArr)) {  // Avoid doubling..
+            $this->initOnceArr[] = $str;
+        };
+    }
+
+    // Function to force pluginParams like "elements" via plugin-code
+    // $value = NULL deletes key completely from editor-config
+    public function setPluginParam($param, $value)
+    {
+        if ($value === NULL) {
+            unset($this->pluginParams[$param]);  // Delete Parameter completely
+        } else {
+            $this->pluginParams[$param] = $value;
+        }
+    }
+
+    // Function to set custom-placeholders like renders javascript-objects, arrays etc
+    // $value = NULL deletes key completely from custom-placeholders
+    public function setPlaceholder($ph, $value)
+    {
+        if ($value === NULL) {
+            unset($this->customPlaceholders[$ph]);  // Delete placeholder completely
+        } else {
+            $this->customPlaceholders[$ph] = $value;
+        }
+    }
+
+    // Set new/overwrite translations manually (via bridge)
+    public function setLang($key, $string, $overwriteExisting = false)
+    {
+        if (is_array($string)) {
+            $this->langArr = $overwriteExisting == false ? array_merge($this->langArr, $string) : array_merge($string, $this->langArr);
+        } else {
+            $this->langArr[$key] = isset($this->langArr[$key]) && $overwriteExisting == false ? $this->langArr[$key] : $string;
+        };
+    }
+
+    // Get translation
+    public function lang($key = '', $returnNull = false)
+    {
+        if (!$key) return;
+        if (isset($this->langArr[$key])) return $this->langArr[$key];
+        return $returnNull ? NULL : 'lang_' . $key;    // Show missing key as fallback
+    }
+
+    // Renders complete JS-Script
+    public function getEditorScript()
+    {
+        global $modx;
+        $ph = array();
+        $output = "<!-- modxRTEbridge {$this->editorKey} -->\n";
+
+        // Init via elements
+        if (isset($this->pluginParams['elements'])) {
+
+            $this->pluginParams['elements'] = !is_array($this->pluginParams['elements']) ? explode(',', $this->pluginParams['elements']) : $this->pluginParams['elements']; // Allow setting via plugin-configuration
+
+            // Now loop through tvs
+            foreach ($this->pluginParams['elements'] as $selector) {
+
+                $this->initTheme($selector);
+                $this->renderBridgeParams($selector);
+
+                // Prepare config output
+                $ph['configString'] = $this->renderConfigString();
+                $ph['configRawString'] = $this->renderConfigRawString();
+                $ph['editorKey'] = $this->editorKey;
+                $ph['themeKey'] = $this->theme;
+                $ph['selector'] = $selector;
+                $ph['documentIdentifier'] = $modx->documentIdentifier;
+
+                $ph = array_merge($ph, $this->customPlaceholders, $this->mergeParamArrays());   // Big list..
+
+                // Init only once at all - Load Editors-Library, CSS etc
+                if (!defined($this->editorKey . '_INIT_ONCE')) {
+                    define($this->editorKey . '_INIT_ONCE', 1);
+                    $output .= file_get_contents("{$this->pluginParams['base_path']}tpl/tpl.{$this->editorKey}.init_once.html") ."\n";
+                    if (!empty($this->initOnceArr)) {
+                        $output .= implode("\n", $this->initOnceArr);
+                    }
+                }
+
+                // Init only once per config (enables multiple config-objects i.e. for richtext / richtextmini via [+configJs+])
+                if (!defined($this->editorKey . '_INIT_CONFIG_' . $this->theme)) {
+                    define($this->editorKey . '_INIT_CONFIG_' . $this->theme, 1);
+                    $output .= file_get_contents("{$this->pluginParams['base_path']}tpl/tpl.{$this->editorKey}.config.html") ."\n";
+                }
+
+                // Loop through tvs
+                $output .= file_get_contents("{$this->pluginParams['base_path']}tpl/tpl.{$this->editorKey}.init.html") ."\n";
+                $output  = $modx->parseText($output, $ph);
+            }
+
+        } else {
+           exit; // @todo: prepare for editors that need no elements
+        }
+
+        // Remove empty placeholders !
+        $placeholderArr = $modx->getTagsFromContent($output, '[+', '+]');
+        if (!empty($placeholderArr)) {
+            foreach ($placeholderArr[1] as $key => $val) {
+                $output = str_replace($placeholderArr[0][$key], '', $output);
+                $this->debugMessages[] = 'Removed empty placeholder: '.$placeholderArr[1];
+            }
+        }
+
+        $output .= $this->renderDebugMessages($ph);
+        $output .= "<!-- / modxRTEbridge {$this->editorKey} -->\n";
+
+        return $output;
+    }
+    
+    // Init/load theme
+    public function initTheme($selector)
+    {
+        global $modx;
+
+        $this->theme = isset($this->tvOptions[$selector]['theme']) ? $this->tvOptions[$selector]['theme'] : $this->theme;
+
+        // Load theme for user or webuser
+        if ($modx->isBackend() || (intval($_GET['quickmanagertv']) == 1 || isset($_SESSION['mgrValidated']))) {
+            // User is logged into Manager
+            // Load base first to assure Modx settings like entermode, editor_css_path are given set, can be overwritten in custom theme
+            include("{$this->pluginParams['base_path']}theme/theme.{$this->editorKey}.base.inc.php");
+            include("{$this->pluginParams['base_path']}theme/theme.{$this->editorKey}.{$this->theme}.inc.php");
+            $this->pluginParams['language'] = !isset($this->pluginParams['language']) ? $this->lang('lang_code') : $this->pluginParams['language'];
+        } else {
+            // User is a webuser
+            $webuserTheme = !empty($this->pluginParams['webTheme']) ? $this->pluginParams['webTheme'] : 'webuser';
+            // Load base first or set EVERYTHING for webuser only in webuser-theme?
+            // include("{$this->pluginParams['base_path']}theme/theme.{$this->editorKey}.base.inc.php");
+            include("{$this->pluginParams['base_path']}theme/theme.{$this->editorKey}.{$webuserTheme}.inc.php");
+            // @todo: determine user-language?
+            $this->pluginParams['language'] = !isset($this->pluginParams['language']) ? $this->lang('lang_code') : $this->pluginParams['language'];
+        }
+    }
+    
+    // Call bridge-functions and receive optional bridged-values
+    public function renderBridgeParams($selector)
+    {
+        // Call functions - for optional translation of params/values via bridge.xxxxxxxxxx.inc.php
+        foreach ($this->bridgeParams as $editorParam => $editorKey) {
+            if (is_callable($this->bridgeParams[$editorParam])) {     // Call function, get return
+                $return = $this->bridgeParams[$editorParam]();
+                if ($return !== NULL && isset($this->themeConfig[$editorParam])) {
+                    $this->themeConfig[$editorParam]['bridged'] = $return;
+                }
+            }
+        }
+        // Load Tv-Options as bridged-params
+        foreach($this->themeConfig as $key=>$conf) {
+            if (isset($this->tvOptions[$selector][$key])) {
+                $this->themeConfig[$key]['bridged'] = $this->tvOptions[$selector][$key];
+            }
+        }
+    }
+
+    // Renders String for initialization via JS
+    public function renderConfigString()
+    {
+        $config = array();
+
+        // Build config-string as per themeConfig
+        $raw = '';
+        foreach ($this->themeConfig as $key => $conf) {
+
+            if ($conf === NULL) { continue; }; // Skip nulled parameters
+            $value = $this->determineValue($key, $conf);
+            if ($value === NULL) { continue; }; // Skip none-allowed empty settings
+
+            // Escape quotes
+            if (!is_array($value) && strpos($value, "'") !== false && $conf['type'] != 'raw')
+                $value = str_replace("'", "\\'", $value);
+
+            // Determine output-type
+            switch ($conf['type']) {
+                case 'string': case 'str':
+                $config[$key] = "        {$key}:'{$value}'";
+                break;
+                case 'array': case 'arr':
+                if (is_array($value)) { $value = "['" . implode("','", $value) . "']"; };
+                $config[$key] = "        {$key}:{$value}";
+                break;
+                case 'boolean': case 'bool':
+                $value = $value == true ? 'true' : 'false';
+                $config[$key] = "        {$key}:{$value}";
+                break;
+                case 'json':
+                    if (is_array($value)) $value = json_encode($value);
+                    $config[$key] = "        {$key}:{$value}";
+                    break;
+                case 'int':
+                case 'constant': case 'const':
+                case 'number':   case 'num':
+                case 'object':   case 'obj':
+                $config[$key] = "        {$key}:{$value}";
+                break;
+                case 'raw':
+                    $raw .= "{$value}\n";
+                    break;
+            };
+        }
+
+        return implode(",\n", $config) . $raw;
+    }
+
+    // Renders String for initialization via JS
+    public function renderConfigRawString()
+    {
+        // Build config-string as per themeConfig
+        $raw = '';
+        foreach ($this->themeConfig as $key => $conf) {
+
+            if ($conf === NULL) { continue; };  // Skip nulled parameters
+            $value = $this->determineValue($key, $conf);
+            if ($value === NULL) { continue; }; // Skip none-allowed empty settings
+
+            if ($conf['type'] == 'raw') {
+                $raw .= "{$value}\n";
+                break;
+            };
+        };
+
+        return $raw;
+    }
+    
+    // Get final value of editor-config  
+    public function determineValue($key, $conf=NULL)
+    {
+        if($conf == NULL) { $conf = $this->themeConfig[$key]; };
+
+        $value = isset($this->themeConfig[$key]['bridged']) ? $this->themeConfig[$key]['bridged'] : NULL;
+        $value = $value === NULL && isset($this->themeConfig[$key]['force']) ? $this->themeConfig[$key]['force'] : $value;
+        $value = $value === NULL ? $this->themeConfig[$key]['value'] : $value;
+
+        if(!in_array($conf['type'], array('boolean','bool'))) {
+            if ($value === '' && $conf['empty'] === false) {  // Empty values not allowed
+                if ($conf['default'] === '') return NULL;    // Skip none-allowed empty setting
+                $value = $conf['default'];
+            };
+        };
+
+        return $value;
+    }
+
+    // Adds initilization before </body> for frontend-editors
+    public function addEditorScriptToBody()
+    {
+        global $modx;
+
+        if (isset($_SESSION['usertype']) && $_SESSION['usertype'] == 'manager') {   // Show only when logged in manager
+            // Add only once
+            if (!defined($this->editorKey . '_ADDED_TO_BODY')) {
+                define($this->editorKey . '_ADDED_TO_BODY', 1);
+                $initJs = $this->getEditorScript();
+
+                // @todo: How to avoid caching of plugins on event "OnParseDocument"?
+                if (strpos($modx->documentOutput, "<!-- modxRTEbridge {$this->editorKey} -->") === false) { // Avoid double init if already cached..
+                    if (strpos($modx->documentOutput, '</body>') !== false) {
+                        // Append to <body>
+                        $modx->documentOutput = str_replace('</body>', $initJs . "</body>", $modx->documentOutput);
+                    } else {
+                        // No <body> - append to source
+                        $modx->documentOutput .= $initJs;
+                    }
+                };
+
+            };
+        };
+    }
+
+    /***************************************************************
+     * SETTINGS PARTS
+     * @todo: make options dynamic to add for example additional options to setting "schema" like html5-strict, html5-bla, or just to "html4 and html5"..
+     ***************************************************************/
+
+    // Outputs Modx- / user-configuration settings
+    public function getModxSettings()
+    {
+        global $modx, $usersettings, $settings;
+        $params = &$this->pluginParams;
+
+        if (defined('INTERFACE_RENDERED_' . $this->editorKey)) {
+            return '';
+        }
+        define('INTERFACE_RENDERED_' . $this->editorKey, 1);
+
+        // Avoid conflicts with older TinyMCE base configs, prepend editorKey to configKey like [+ckeditor4_custom_plugins+]
+        $prependModxParams = array();
+        foreach ($this->modxParams as $key => $val) {
+            $prependModxParams[$this->editorKey . '_' . $key] = $val;
+        }
+
+        $ph = array_merge($prependModxParams, $params);
+
+        // Prepare [+display+]
+        $ph['display'] = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
+        $ph['display'] = $modx->config['use_editor'] == 1 ? $ph['display'] : 'none';
+
+        // Prepare setting "editor_theme"
+        $theme_options = '';
+        switch ($modx->manager->action) {
+            case '11';
+            case '12';
+            case '119';
+                $selected = empty($ph[$this->editorKey . '_theme']) ? '"selected"' : '';
+                $theme_options .= '<option value="" ' . $selected . '>' . $this->lang('theme_global_settings') . "</option>\n";
+        }
+
+        // Prepare setting "theme"
+        $ph['theme_options'] = $this->getThemeNames();
+
+        // Prepare setting "skin"
+        $ph['skin_options'] = $this->getSkinNames();
+
+        // Prepare setting "entermode_options"
+        $entermode = !empty($ph[$this->editorKey . '_entermode']) ? $ph[$this->editorKey . '_entermode'] : 'p';
+        $ph['entermode_options'] = '<label><input name="[+name+]" type="radio" value="p" ' . $this->checked($entermode == 'p') . '/>' . $this->lang('entermode_opt1') . '</label><br />';
+        $ph['entermode_options'] .= '<label><input name="[+name+]" type="radio" value="br" ' . $this->checked($entermode == 'br') . '/>' . $this->lang('entermode_opt2') . '</label>';
+        switch ($modx->manager->action) {
+            case '11':
+            case '12':
+            case '119':
+                $ph['entermode_options'] .= '<br />';
+                $ph['entermode_options'] .= '<label><input name="[+name+]" type="radio" value="" ' . $this->checked(empty($params[$this->editorKey . '_entermode'])) . '/>' . $this->lang('theme_global_settings') . '</label><br />';
+                break;
+        }
+
+        // Prepare setting "element_format_options"
+        $element_format = !empty($ph[$this->editorKey . '_element_format']) ? $ph[$this->editorKey . '_element_format'] : 'xhtml';
+        $ph['element_format_options'] = '<label><input name="[+name+]" type="radio" value="xhtml" ' . $this->checked($element_format == 'xhtml') . '/>XHTML</label><br />';
+        $ph['element_format_options'] .= '<label><input name="[+name+]" type="radio" value="html" ' . $this->checked($element_format == 'html') . '/>HTML</label>';
+        switch ($modx->manager->action) {
+            case '11':
+            case '12':
+            case '119':
+                $ph['element_format_options'] .= '<br />';
+                $ph['element_format_options'] .= '<label><input name="[+name+]" type="radio" value="" ' . $this->checked(empty($params[$this->editorKey . '_element_format'])) . '/>' . $this->lang('theme_global_settings') . '</label><br />';
+                break;
+        }
+
+        // Prepare setting "schema_options"
+        $schema = !empty($ph[$this->editorKey . '_schema']) ? $ph[$this->editorKey . '_schema'] : 'html5';
+        $ph['schema_options'] = '<label><input name="[+name+]" type="radio" value="html4" ' . $this->checked($schema == 'html4') . '/>HTML4(XHTML)</label><br />';
+        $ph['schema_options'] .= '<label><input name="[+name+]" type="radio" value="html5" ' . $this->checked($schema == 'html5') . '/>HTML5</label><br />';
+        $ph['schema_options'] .= '<label><input name="[+name+]" type="radio" value="html5-strict" ' . $this->checked($schema == 'html5-strict') . '/>HTML5-strict</label>';
+        switch ($modx->manager->action) {
+            case '11':
+            case '12':
+            case '119':
+                $ph['schema_options'] .= '<br />';
+                $ph['schema_options'] .= '<label><input name="[+name+]" type="radio" value="" ' . $this->checked(empty($params[$this->editorKey . '_schema'])) . '/>' . $this->lang('theme_global_settings') . '</label><br />';
+                break;
+        };
+
+        // Prepare settings rows output
+        include($params['base_path'] . 'gsettings/gsettings.rows.inc.php');
+        $settingsRowTpl = file_get_contents("{$params['base_path']}gsettings/gsettings.row.inc.html");
+        $settingsRows = isset($settingsRows) ? array_merge($settingsRows, $this->gSettingsCustom) : $this->gSettingsCustom;
+
+        $ph['rows'] = '';
+        foreach ($settingsRows as $name => $row) {
+
+            if ($row == NULL) {
+                continue;
+            };     // Skip disabled config-settings
+
+            $row['name'] = $this->editorKey . '_' . $name;
+            $row['editorKey'] = $this->editorKey;
+            $row['title'] = $this->lang($row['title']);
+            $row['message'] = $this->lang($row['message']);
+            $row['messageVal'] = !empty($row['messageVal']) ? $row['messageVal'] : '';
+
+            // Prepare displaying of default values
+            $row['default'] = isset($this->gSettingsDefaultValues[$name]) ? '<span class="default-val" style="margin:0.5em 0;float:left;">' . $this->lang('default') . '<i>' . $this->gSettingsDefaultValues[$name] . '</i></span>' : '';
+
+            // Enable nested parsing
+            $output = $modx->parseText($settingsRowTpl, $row); // Replace general translations
+            $output = $modx->parseText($output, $ph);          // Replace values / settings
+            $output = $modx->parseText($output, $row);         // Replace new PHs from values / settings
+
+            // Replace missing translations
+            $output = $this->replaceTranslations($output);
+
+            $ph['rows'] .= $output . "\n";
+        };
+
+        $settingsBody = file_get_contents("{$params['base_path']}gsettings/gsettings.body.inc.html");
+
+        $ph['editorLogo'] = !empty($this->pluginParams['editorLogo']) ? '<img src="' . $this->pluginParams['base_url'] . $this->pluginParams['editorLogo'] . '" style="max-height:50px;width:auto;margin-right:50px;" />' : '';
+
+        $settingsBody = $modx->parseText($settingsBody, $ph);
+        $settingsBody = $this->replaceTranslations($settingsBody);
+
+        return $settingsBody;
+    }
+    
+    // Replace all translation-placeholders
+    public function replaceTranslations($output)
+    {
+        global $modx;
+
+        $placeholderArr = $modx->getTagsFromContent($output, '[+', '+]');
+        if (!empty($placeholderArr)) {
+            foreach ($placeholderArr[1] as $key => $val) {
+                $trans = $this->lang($val, true);
+
+                if ($trans !== NULL)
+                    $output = str_replace($placeholderArr[0][$key], $trans, $output);
+            };
+        };
+        return $output;
+    }
+
+    // helpers for getModxSettings()
+    public function getThemeNames()
+    {
+        global $modx;
+        $params = $this->pluginParams;
+
+        $themeDir = "{$params['base_path']}theme/";
+
+        switch ($modx->manager->action) {
+            case '11':
+            case '12':
+            case '119':
+                $selected = $this->selected(empty($params[$this->editorKey . '_skin']));
+                $option[] = '<option value=""' . $selected . '>' . $this->lang('theme_global_settings') . '</option>';
+                break;
+        }
+
+        foreach (glob("{$themeDir}*") as $file) {
+            $file = str_replace('\\', '/', $file);
+            $file = str_replace($themeDir, '', $file);
+            $file = str_replace('theme.' . $this->editorKey . '.', '', $file);
+
+            $theme = trim(str_replace('.inc.php', '', $file));
+            if ($theme == 'base') continue; // Why should user select base-theme?
+            $label = $this->lang("theme_{$theme}", true) ? $this->lang("theme_{$theme}") : $theme; // Get optional translation or show raw themeKey
+            $selected = $this->selected($theme == $this->modxParams['theme']);
+
+            $label = $modx->parseText($label, $this->pluginParams);   // Enable [+editorLabel+] in options-label
+
+            $option[] = '<option value="' . $theme . '"' . $selected . '>' . "{$label}</option>";
+        }
+
+        return isset($option) && is_array($option) ? implode("\n", $option) : '<!-- ' . $this->editorKey . ': No themes found -->';
+    }
+
+    public function getSkinNames()
+    {
+        global $modx, $usersettings, $settings;
+        $params = $this->pluginParams;
+
+        if (empty($params['skinsDirectory'])) {
+            return '<option value="">No skinsDirectory set</option>';
+        };
+
+        $skinDir = "{$params['base_path']}{$params['skinsDirectory']}";
+
+        switch ($modx->manager->action) {
+            case '11':
+            case '12':
+            case '119':
+                $selected = $this->selected(empty($params[$this->editorKey . '_skin']));
+                $option[] = '<option value=""' . $selected . '>' . $this->lang('theme_global_settings') . '</option>';
+                break;
+        }
+        foreach (glob("{$skinDir}*", GLOB_ONLYDIR) as $dir) {
+            $dir = str_replace('\\', '/', $dir);
+            $skin_name = substr($dir, strrpos($dir, '/') + 1);
+            $skins[$skin_name][] = 'default';
+            $styles = glob("{$dir}/ui_*.css");
+            if (is_array($styles) && 0 < count($styles)) {
+                foreach ($styles as $css) {
+                    $skin_variant = substr($css, strrpos($css, '_') + 1);
+                    $skin_variant = substr($skin_variant, 0, strrpos($skin_variant, '.'));
+                    $skins[$skin_name][] = $skin_variant;
+                }
+            }
+            foreach ($skins as $k => $o) ;
+            {
+                foreach ($o as $v) {
+                    if ($v === 'default') $value = $k;
+                    else               $value = "{$k}:{$v}";
+                    $selected = $this->selected($value == $this->modxParams['skin']);
+                    $option[] = '<option value="' . $value . '"' . $selected . '>' . "{$value}</option>";
+                }
+            }
+        }
+
+        return is_array($option) ? implode("\n", $option) : '<!-- ' . $this->editorKey . ': No skins found -->';
+    }
+
+    public function selected($cond = false)
+    {
+        if ($cond !== false) return ' selected="selected"';
+        else                return '';
+    }
+    public function checked($cond = false)
+    {
+        if ($cond !== false) return ' checked="checked"';
+        else                return '';
+    }
+
+
+
+    // Init translations
+    public function initLang($basePath)
+    {
+        global $modx;
+
+        // Init langArray once
+        if (empty($this->langArr)) {
+            $lang_name = $modx->config['manager_language'];
+            $gsettings_path = $basePath . "lang/gsettings/";     // Holds general translations
+            $custom_path = $basePath . "lang/custom/";        // Holds custom translations
+            $lang_file = $lang_name . '.inc.php';
+            $fallback_file = 'english.inc.php';
+            $lang_code = '';
+
+            // Load gsettings fallback language (show at least english translations instead of empty)
+            if (is_file($gsettings_path . $fallback_file)) include($gsettings_path . $fallback_file);
+            if (isset($_lang['lang_code'])) $lang_code = $_lang['lang_code'];    // Set langcode for RTE
+
+            // Load gsettings user language
+            if (is_file($custom_path . $fallback_file)) include($custom_path . $fallback_file);
+            if (isset($_lang['lang_code'])) $lang_code = $_lang['lang_code'];    // Set langcode for RTE
+
+            // Load custom settings fallback language
+            if (is_file($gsettings_path . $lang_file)) include($gsettings_path . $lang_file);
+            if (isset($_lang['lang_code'])) $lang_code = $_lang['lang_code'];    // Set langcode for RTE
+
+            // Load custom settings user language
+            if (is_file($custom_path . $lang_file)) include($custom_path . $lang_file);
+            if (isset($_lang['lang_code'])) $lang_code = $_lang['lang_code'];    // Set langcode for RTE
+
+            $this->langArr = $_lang;
+            $this->langArr['lang_code'] = $lang_code;
+        };
+    }
+
+    // Merges all available config-params with prefixes into single array
+    public function mergeParamArrays()
+    {
+        $p = array();
+        foreach($this->pluginParams as $param=>$value) { $p['pp.'.$param] = is_array($value) ? join(',',$value) : $value; };
+        foreach($this->modxParams   as $param=>$value) { $p['mp.'.$param] = is_array($value) ? join(',',$value) : $value; };
+        foreach($this->themeConfig  as $param=>$arr) {
+            if (isset($arr['force'])) $p['tc.' . $param] = $arr['force'];
+            elseif (isset($arr['bridged'])) $p['tc.' . $param] = $arr['bridged'];
+            else $p['tc.' . $param] = $arr['value'];
+        };
+        foreach($this->gSettingsDefaultValues as $param=>$value) { $p['gd.'.$param] = is_array($value) ? join(',',$value) : $value; };
+        foreach($this->langArr as $param=>$value)      { $p['l.'.$param] = $value; };
+        return $p;
+    }
+
+    // Get PluginConfiguration by Connectors
+    public function getModxPluginConfiguration($pluginName)
+    {
+        global $modx;
+
+        if( $pluginName != NULL ) {
+            if (empty ($modx->config)) { $modx->getSettings(); };
+            $modx->db->connect();
+
+            $plugin = $modx->getPluginCode($pluginName);
+            $parameter = $modx->parseProperties($plugin['props'], $pluginName, 'plugin');
+
+            if (is_array($parameter)) {
+                $this->pluginParams = array_merge($parameter, $this->pluginParams);
+            };
+        };
+        return $this->pluginParams;
+    }
+
+    // Remove all but numbers
+    public function onlyNumbers($string)
+    {
+        return preg_replace("/[^0-9]/", "", $string); // Remove px, % etc
+    }
+
+    // Helper to translate "bold,strike,underline,italic" to "bold","strike","underline","italic"
+    // Translates Modx Plugin-configuration strings to JSON-compatible string
+    public function addQuotesToCommaList($str, $quote = '"')
+    {
+        if (empty($str)) { return ''; }
+
+        $elements = explode(',', $str);
+        foreach ($elements as $key => $val) {
+            $elements[$key] = $quote . trim($val) . $quote;
+        };
+        return implode(',', $elements);
+    }
+
+    // Helper to avoid Placeholder-/Snippet-Execution for Frontend-Editors
+    public function protectModxPhs($placeholderArr, $setSep=',', $phLink='->')
+    {
+        global $modx;
+
+        if(!is_array($placeholderArr)) {
+            $editablesArr = explode($setSep, $placeholderArr);
+            foreach ($editablesArr as $idStr) {
+                $exp = explode($phLink, $idStr);
+                $editableIds[$exp[0]] = $exp[1];
+            }
+        } else {
+            $editableIds = $placeholderArr;
+        }
+
+        foreach ($editableIds as $modxPh=>$cssId) {
+            if (isset($modx->documentObject[$modxPh]))
+                $modx->documentObject[$modxPh] = $this->protectModxPlaceholders($modx->documentObject[$modxPh]);
+        }
+    }
+
+    public function protectModxPlaceholders($output)
+    {
+        return str_replace(
+            array('[*',     '*]',     '[(',     ')]',     '{{',           '}}',           '[[',         ']]',         '[!',     '!]',     '[+',     '+]',     '[~',     '~]'),
+            array('&#91;*', '*&#93;', '&#91;(', ')&#93;', '&#123;&#123;', '&#125;&#125;', '&#91;&#91;', '&#93;&#93;', '&#91;!', '!&#93;', '&#91;+', '+&#93;', '&#91;~', '~&#93;'),
+            $output
+        );
+    }
+    public function unprotectModxPlaceholders($output)
+    {
+        return str_replace(
+            array('&#91;*', '*&#93;', '&#91;(', ')&#93;', '&#123;&#123;', '&#125;&#125;', '&#91;&#91;', '&#93;&#93;', '&#91;!', '!&#93;', '&#91;+', '+&#93;', '&#91;~', '~&#93;'),
+            array('[*', '*]', '[(', ')]', '{{', '}}', '[[', ']]', '[!', '!]', '[+', '+]', '[~', '~]'),
+            $output
+        );
+    }
+
+    // Handle debug-modes
+    public function setDebug($state)
+    {
+        if($state == 'full') $this->debug = 'full';
+        else if($state != false) $this->debug = true;
+        else $this->debug = false;
+    }
+
+    public function renderDebugMessages($placeholderArr) {
+        $output = '';
+        if($this->debug)
+        {
+            $output .= "<!-- ##### modxRTEbridge Debug Infos #########\n";
+            $output .= " - ". join("\n - ", $this->debugMessages);
+
+            if($this->debug == 'full') {
+                $output .= "this->modxParams = ".print_r($this->modxParams, true)."\n";
+                $output .= "this->pluginParams = ".print_r($this->pluginParams, true)."\n";
+                $output .= "this->themeConfig = ".print_r($this->themeConfig, true)."\n";
+                $output .= "this->gSettingsCustom = ".print_r($this->gSettingsCustom, true)."\n";
+                $output .= "this->gSettingsDefaultValues = ".print_r($this->gSettingsDefaultValues, true)."\n";
+                $output .= "ph = ".print_r($placeholderArr, true)."\n";
+            };
+
+            $output .= "\n     ##### modxRTEbridge Debug Infos End ##### -->\n";
+        }
+        return $output;
+    }
+
+    /***************************************************************
+     * Connectors
+     **************************************************************/
+    public function getTemplateChunkList()
+    {
+        global $modx;
+
+        $templatesArr = array();
+        /* only display if manager user is logged in */
+        if ($modx->getLoginUserType() === 'manager') {
+
+            $modx->getSettings();
+            $ids    = $modx->config[$this->editorKey.'_template_docs'];
+            $chunks = $modx->config[$this->editorKey.'_template_chunks'];
+            $templatesArr = array();
+
+            if (!empty($ids)) {
+                $docs = $modx->getDocuments($modx->db->escape($ids), 1, 0, $fields = 'id,pagetitle,menutitle,description,content');
+                foreach ($docs as $i => $a) {
+                    $newTemplate = array(
+                        'title'=>($docs[$i]['menutitle'] !== '') ? $docs[$i]['menutitle'] : $docs[$i]['pagetitle'],
+                        'description'=>$docs[$i]['description'],
+                        'content'=>$docs[$i]['content']
+                    );
+                    $templatesArr[] = $newTemplate;
+                }
+            }
+
+            if (!empty($chunks)) {
+                $tbl_site_htmlsnippets = $modx->getFullTableName('site_htmlsnippets');
+                if (strpos($chunks, ',') !== false) {
+                    $chunks  = array_filter(array_map('trim', explode(',', $chunks)));
+                    $chunks  = $modx->db->escape($chunks);
+                    $chunks  = implode("','", $chunks);
+                    $where   = "`name` IN ('{$chunks}')";
+                    $orderby = "FIELD(name, '{$chunks}')";
+                } else {
+                    $where   = "`name`='{$chunks}'";
+                    $orderby = '';
+                }
+
+                $rs = $modx->db->select('id,name,description,snippet', $tbl_site_htmlsnippets, $where, $orderby);
+
+                while ($row = $modx->db->getRow($rs)) {
+                    $newTemplate = array(
+                        'title'=>$row['name'],
+                        'description'=>$row['description'],
+                        'content'=>$row['snippet']
+                    );
+                    $templatesArr[] = $newTemplate;
+                }
+            }
+        }
+        return $templatesArr;
+    }
+
+    // Plugin-configuration: &editableIds=Editable Ids<br/>Modx-Phs->CSS-IDs;text;longtitle->#modx_longtitle,content->#modx_content
+    public function saveContentProcessor($rid, $ppPluginName, $ppEditableIds='editableIds')
+    {
+        global $modx;
+
+        if ($rid > 0 && $modx->getLoginUserType() === 'manager')
+        {
+            $this->getModxPluginConfiguration($ppPluginName);
+
+            $editableIds = explode(',', $this->pluginParams[$ppEditableIds]);
+
+            if($editableIds) {
+                include_once(MODX_BASE_PATH . "assets/lib/MODxAPI/modResource.php");
+
+                $modx->doc = new modResource($modx);
+                $modx->doc->edit($rid);
+
+                foreach ($editableIds as $idStr) {
+
+                    $editable = explode('->', $idStr);
+                    $modxPh = trim($editable[0]);
+
+                    if (isset($_POST[$modxPh]) && $_POST[$modxPh] != 'undefined') // Prevent if Javascript returned "undefined"
+                        $modx->doc->set($modxPh, $this->unprotectModxPlaceholders($_POST[$modxPh]));
+                };
+                return $modx->doc->save(true, true);    // Returns ressource-ID
+            }
+
+            return 'editableIds not given in plugin-configuration with config-key "'. $ppEditableIds .'"';
+
+        } else {
+            return 'Not logged into manager!';
+        }
+    }
+}

--- a/assets/plugins/codemirror/codemirror.plugin.php
+++ b/assets/plugins/codemirror/codemirror.plugin.php
@@ -11,7 +11,7 @@
  *
  * @confirmed   MODX Evolution 1.0.15
  *
- * @author      Mihanik71 
+ * @author      Mihanik71
  *
  * @see         https://github.com/Mihanik71/CodeMirror-MODx
  */
@@ -19,242 +19,284 @@ global $content, $which_editor;
 $textarea_name = 'post';
 $mode = 'htmlmixed';
 $lang = 'htmlmixed';
-$object_id = md5($evt->name.'-'.$content['id']);
+$object_id = md5($evt->name . '-' . $content['id']);
 /*
  * Default Plugin configuration
  */
-$theme                  = (isset($theme)                    ? $theme                    : 'default');
-$indentUnit             = (isset($indentUnit)               ? $indentUnit               : 4);
-$tabSize                = (isset($tabSize)                  ? $tabSize                  : 4);
-$lineWrapping           = (isset($lineWrapping)             ? $lineWrapping             : false);
-$matchBrackets          = (isset($matchBrackets)            ? $matchBrackets            : false);
-$activeLine           	= (isset($activeLine)               ? $activeLine            	: false);
-$emmet			= (($emmet == 'true')? 	'<script src="'.$_CM_URL.'cm/emmet-compressed.js"></script>' 	: "");
-$search			= (($search == 'true')? '<script src="'.$_CM_URL.'cm/search-compressed.js"></script>' 	: "");
+$theme = (isset($theme) ? $theme : 'default');
+$indentUnit = (isset($indentUnit) ? $indentUnit : 4);
+$tabSize = (isset($tabSize) ? $tabSize : 4);
+$lineWrapping = (isset($lineWrapping) ? $lineWrapping : false);
+$matchBrackets = (isset($matchBrackets) ? $matchBrackets : false);
+$activeLine = (isset($activeLine) ? $activeLine : false);
+$emmet = (($emmet == 'true') ? '<script src="' . $_CM_URL . 'cm/emmet-compressed.js"></script>' : "");
+$search = (($search == 'true') ? '<script src="' . $_CM_URL . 'cm/search-compressed.js"></script>' : "");
 /*
  * This plugin is only valid in "text" mode. So check for the current Editor
  */
-$prte   = (isset($_POST['which_editor']) ? $_POST['which_editor'] : '');
-$srte   = ($modx->config['use_editor'] ? $modx->config['which_editor'] : 'none');
-$xrte   = $content['richtext'];
+$prte = (isset($_POST['which_editor']) ? $_POST['which_editor'] : '');
+$srte = ($modx->config['use_editor'] ? $modx->config['which_editor'] : 'none');
+$xrte = $content['richtext'];
+$tvMode = false;
 /*
  * Switch event
  */
-switch($modx->Event->name) {
+switch ($modx->Event->name) {
     case 'OnTempFormRender'   :
         $object_name = $content['templatename'];
-        $rte   = ($prte ? $prte : 'none');
+        $rte = ($prte ? $prte : 'none');
         break;
     case 'OnChunkFormRender'  :
-        $rte   = isset($which_editor) ? $which_editor : 'none';
+        $rte = isset($which_editor) ? $which_editor : 'none';
         break;
 
-    case 'OnDocFormRender'    :
-        $textarea_name    = 'ta';
+    case 'OnRichTextEditorInit':
+        if ($editor !== 'Codemirror') return;
+        $textarea_name = $modx->event->params['elements'];
         $object_name = $content['pagetitle'];
-        $xrte  = (('htmlmixed' == $mode) ? $xrte : 0);
-        $rte   = ($prte ? $prte : ($content['id'] ? ($xrte ? $srte : 'none') : $srte));
-		$contentType = $content['contentType'];
-		/*
-		* Switch contentType for doc
-		*/
-		switch($contentType){
-			case "text/css":
-				$mode = "text/css";
-				$lang = "css";
-			break;
-			case "text/javascript":
-				$mode = "text/javascript";
-				$lang = "javascript";
-			break;
-			case "application/json":
-				$mode = "application/json";
-				$lang = "javascript";
-			break;
-		}
+        $rte = 'none';
+        $tvMode = true;
+        $contentType = $content['contentType'];
+        /*
+        * Switch contentType for doc
+        */
+        switch ($contentType) {
+            case "text/css":
+                $mode = "text/css";
+                $lang = "css";
+                break;
+            case "text/javascript":
+                $mode = "text/javascript";
+                $lang = "javascript";
+                break;
+            case "application/json":
+                $mode = "application/json";
+                $lang = "javascript";
+                break;
+        }
+        break;
+    case 'OnDocFormRender'     :
+        $textarea_name = 'ta';
+        $object_name = $content['pagetitle'];
+        $xrte = (('htmlmixed' == $mode) ? $xrte : 0);
+        $rte = ($prte ? $prte : ($content['id'] ? ($xrte ? $srte : 'none') : $srte));
+        $contentType = $content['contentType'];
+        /*
+        * Switch contentType for doc
+        */
+        switch ($contentType) {
+            case "text/css":
+                $mode = "text/css";
+                $lang = "css";
+                break;
+            case "text/javascript":
+                $mode = "text/javascript";
+                $lang = "javascript";
+                break;
+            case "application/json":
+                $mode = "application/json";
+                $lang = "javascript";
+                break;
+        }
         break;
 
     case 'OnSnipFormRender'   :
     case 'OnPluginFormRender' :
     case 'OnModFormRender'    :
-        $mode  = 'application/x-httpd-php-open';
-        $rte   = ($prte ? $prte : 'none');
-		$lang = "php";
+        $mode = 'application/x-httpd-php-open';
+        $rte = ($prte ? $prte : 'none');
+        $lang = "php";
         break;
 
     case 'OnManagerPageRender':
         if ((31 == $action) && (('view' == $_REQUEST['mode']) || ('edit' == $_REQUEST['mode']))) {
             $textarea_name = 'content';
-            $rte   = 'none';
+            $rte = 'none';
         }
         break;
 
     default:
-        $this->logEvent(1, 2, 'Undefined event : <b>'.$modx->Event->name.'</b> in <b>'.$this->Event->activePlugin.'</b> Plugin', 'CodeMirror Plugin : '.$modx->Event->name);
+        $this->logEvent(1, 2, 'Undefined event : <b>' . $modx->Event->name . '</b> in <b>' . $this->Event->activePlugin . '</b> Plugin', 'CodeMirror Plugin : ' . $modx->Event->name);
 }
-if (('none' == $rte) && $mode) {
+$output = '';
+if (('none' == $rte) && $mode && !defined('INIT_CODEMIRROR')) {
+    define('INIT_CODEMIRROR', 1);
     $output = <<< HEREDOC
-	<link rel="stylesheet" href="{$_CM_URL}cm/lib/codemirror.css">
-	<link rel="stylesheet" href="{$_CM_URL}cm/theme/{$theme}.css">
-	<script src="{$_CM_URL}cm/lib/codemirror-compressed.js"></script>
-	<script src="{$_CM_URL}cm/addon-compressed.js"></script>
-	<script src="{$_CM_URL}cm/mode/{$lang}-compressed.js"></script>
-	{$emmet}{$search}
-	
-	<script type="text/javascript">
-		// Add mode MODX for syntax highlighting. Dfsed on $mode
-		CodeMirror.defineMode("MODx-{$mode}", function(config, parserConfig) {
-			var mustacheOverlay = {
-				token: function(stream, state) {
-					var ch;
-					if (stream.match("[[")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "?" || (ch == "]"&& stream.next() == "]")) break;
-						return "modxSnippet";
-					}
-					if (stream.match("{{")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "}" && stream.next() == "}") break;
-						stream.eat("}");
-						return "modxChunk";
-					}
-					if (stream.match("[*")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "*" && stream.next() == "]") break;
-						stream.eat("]");
-						return "modxTv";
-					}
-					if (stream.match("[+")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "+" && stream.next() == "]") break;
-						stream.eat("]");
-						return "modxPlaceholder";
-					}
-					if (stream.match("[!")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "?" || (ch == "!"&& stream.next() == "]")) break;
-						return "modxSnippetNoCache";
-					}
-					if (stream.match("[(")) {
-						while ((ch = stream.next()) != null)
-							if (ch == ")" && stream.next() == "]") break;
-						stream.eat("]");
-						return "modxVariable";
-					}
-					if (stream.match("[~")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "~" && stream.next() == "]") break;
-						stream.eat("]");
-						return "modxUrl";
-					}
-					if (stream.match("[^")) {
-						while ((ch = stream.next()) != null)
-							if (ch == "^" && stream.next() == "]") break;
-						stream.eat("]");
-						return "modxConfig";
-					}
-					if (stream.match(/&([^\s;]+;)?([^\s=]+=)?/)) {
-						return "attribute";
-					}
-					if (stream.match("!]")) {
-						return "modxSnippet";
-					}
-					if (stream.match("]]")) {
-						return "modxSnippetNoCache";
-					}
-					while (stream.next() != null && !stream.match("[[", false) && !stream.match("&", false) && !stream.match("{{", false) && !stream.match("[*", false) && !stream.match("[+", false) && !stream.match("[!", false) && !stream.match("[(", false) && !stream.match("[~", false) && !stream.match("[^", false) && !stream.match("!]", false) && !stream.match("]]", false)) {}
-					return null;
-				}
-			};
-			return CodeMirror.overlayMode(CodeMirror.getMode(config, parserConfig.backdrop || "{$mode}"), mustacheOverlay);
-		});
-		//Basic settings
-		var config = {
-			mode: 'MODx-{$mode}',
-			theme: '{$theme}',
-			indentUnit: {$indentUnit},
-			tabSize: {$tabSize},
-			lineNumbers: true,
-			matchBrackets: {$matchBrackets},
-			lineWrapping: {$lineWrapping},
-			gutters: ["CodeMirror-linenumbers", "breakpoints"],
-			styleActiveLine: {$activeLine},
-			indentWithTabs: {$indentWithTabs},
-			extraKeys:{
-				"Ctrl-Space": function(cm){
-					var n = cm.getCursor().line;
-					var info = cm.lineInfo(n);
-					foldFunc(cm, n);
-					cm.setGutterMarker(n, "breakpoints", info.gutterMarkers ? null : makeMarker("+"));
-				},
-				"F11": function(cm) {
-					setFullScreen(cm, !isFullScreen(cm));
-					localStorage["cm_fullScreen_{$object_id}"] = isFullScreen(cm);
-				},
-				"Esc": function(cm) {
-					if (isFullScreen(cm)){
-						setFullScreen(cm, false);
-						localStorage["cm_fullScreen_{$object_id}"] = "false";
-					}
-				},
-				"Ctrl-S": function(cm) {
-					document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
-				},
-				"Ctrl-E": function(cm) {
-					document.getElementById('Button1').getElementsByTagName('select')[0].options[1].selected = true;
-					document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
-				},
-				"Ctrl-B": function(cm) {
-					document.getElementById('Button1').getElementsByTagName('select')[0].options[0].selected = true;
-					document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
-				},
-				"Ctrl-Q": function(cm) {
-					document.getElementById('Button1').getElementsByTagName('select')[0].options[2].selected = true;
-					document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
-				}
-			}
-		};
-		var foldFunc = CodeMirror.newFoldFunction(CodeMirror.tagRangeFinder);
-		var myTextArea = document.getElementsByName('{$textarea_name}')[0];
-		var myCodeMirror = (CodeMirror.fromTextArea(myTextArea, config));
-		// reset onchange tab
-		$$('.tab-row .tab').addEvents({
-			click: function() {
-				myCodeMirror.refresh();
-			}
-		});
-		// get data in localStorage
-		if ("true" == localStorage["cm_fullScreen_{$object_id}"]){
-			setFullScreen(myCodeMirror, !isFullScreen(myCodeMirror));
-			myCodeMirror.hasFocus();
-		}
-		if (localStorage["history_{$object_id}"] !== undefined){
-			var cmHistory = JSON.parse(localStorage["history_{$object_id}"]);
-			myCodeMirror.doc.setHistory(cmHistory);
-		}
-		// add event
-		myCodeMirror.on("gutterClick", function(cm, n) {
-			var info = cm.lineInfo(n);
-			foldFunc(cm, n);
-			cm.setGutterMarker(n, "breakpoints", info.gutterMarkers ? null : makeMarker("+"));
-		});
-		myCodeMirror.on("change", function(cm, n) {
-			var cmHistory = myCodeMirror.doc.getHistory();
-			localStorage['history_{$object_id}'] = JSON.stringify(cmHistory);
-			documentDirty=true;
-		});
-
-		(function() {
-			var tId = setInterval(function() {
-				if (document.readyState == "complete")
-					onComplete();
-			}, 11);
-			function onComplete() {
-				clearInterval(tId);
-				myCodeMirror.refresh();
-			};
-		})();
+    <link rel="stylesheet" href="{$_CM_URL}cm/lib/codemirror.css">
+    <link rel="stylesheet" href="{$_CM_URL}cm/theme/{$theme}.css">
+    <script src="{$_CM_URL}cm/lib/codemirror-compressed.js"></script>
+    <script src="{$_CM_URL}cm/addon-compressed.js"></script>
+    <script src="{$_CM_URL}cm/mode/{$lang}-compressed.js"></script>
+    {$emmet}{$search}
+    
+    <script type="text/javascript">
+        // Add mode MODX for syntax highlighting. Dfsed on $mode
+        CodeMirror.defineMode("MODx-{$mode}", function(config, parserConfig) {
+            var mustacheOverlay = {
+                token: function(stream, state) {
+                    var ch;
+                    if (stream.match("[[")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "?" || (ch == "]"&& stream.next() == "]")) break;
+                        return "modxSnippet";
+                    }
+                    if (stream.match("{{")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "}" && stream.next() == "}") break;
+                        stream.eat("}");
+                        return "modxChunk";
+                    }
+                    if (stream.match("[*")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "*" && stream.next() == "]") break;
+                        stream.eat("]");
+                        return "modxTv";
+                    }
+                    if (stream.match("[+")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "+" && stream.next() == "]") break;
+                        stream.eat("]");
+                        return "modxPlaceholder";
+                    }
+                    if (stream.match("[!")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "?" || (ch == "!"&& stream.next() == "]")) break;
+                        return "modxSnippetNoCache";
+                    }
+                    if (stream.match("[(")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == ")" && stream.next() == "]") break;
+                        stream.eat("]");
+                        return "modxVariable";
+                    }
+                    if (stream.match("[~")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "~" && stream.next() == "]") break;
+                        stream.eat("]");
+                        return "modxUrl";
+                    }
+                    if (stream.match("[^")) {
+                        while ((ch = stream.next()) != null)
+                            if (ch == "^" && stream.next() == "]") break;
+                        stream.eat("]");
+                        return "modxConfig";
+                    }
+                    if (stream.match(/&([^\s;]+;)?([^\s=]+=)?/)) {
+                        return "attribute";
+                    }
+                    if (stream.match("!]")) {
+                        return "modxSnippet";
+                    }
+                    if (stream.match("]]")) {
+                        return "modxSnippetNoCache";
+                    }
+                    while (stream.next() != null && !stream.match("[[", false) && !stream.match("&", false) && !stream.match("{{", false) && !stream.match("[*", false) && !stream.match("[+", false) && !stream.match("[!", false) && !stream.match("[(", false) && !stream.match("[~", false) && !stream.match("[^", false) && !stream.match("!]", false) && !stream.match("]]", false)) {}
+                    return null;
+                }
+            };
+            return CodeMirror.overlayMode(CodeMirror.getMode(config, parserConfig.backdrop || "{$mode}"), mustacheOverlay);
+        });
+        //Basic settings
+        var config = {
+            mode: 'MODx-{$mode}',
+            theme: '{$theme}',
+            indentUnit: {$indentUnit},
+            tabSize: {$tabSize},
+            lineNumbers: true,
+            matchBrackets: {$matchBrackets},
+            lineWrapping: {$lineWrapping},
+            gutters: ["CodeMirror-linenumbers", "breakpoints"],
+            styleActiveLine: {$activeLine},
+            indentWithTabs: {$indentWithTabs},
+            extraKeys:{
+                "Ctrl-Space": function(cm){
+                    var n = cm.getCursor().line;
+                    var info = cm.lineInfo(n);
+                    foldFunc(cm, n);
+                    cm.setGutterMarker(n, "breakpoints", info.gutterMarkers ? null : makeMarker("+"));
+                },
+                "F11": function(cm) {
+                    setFullScreen(cm, !isFullScreen(cm));
+                    localStorage["cm_fullScreen_{$object_id}"] = isFullScreen(cm);
+                },
+                "Esc": function(cm) {
+                    if (isFullScreen(cm)){
+                        setFullScreen(cm, false);
+                        localStorage["cm_fullScreen_{$object_id}"] = "false";
+                    }
+                },
+                "Ctrl-S": function(cm) {
+                    document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
+                },
+                "Ctrl-E": function(cm) {
+                    document.getElementById('Button1').getElementsByTagName('select')[0].options[1].selected = true;
+                    document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
+                },
+                "Ctrl-B": function(cm) {
+                    document.getElementById('Button1').getElementsByTagName('select')[0].options[0].selected = true;
+                    document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
+                },
+                "Ctrl-Q": function(cm) {
+                    document.getElementById('Button1').getElementsByTagName('select')[0].options[2].selected = true;
+                    document.getElementById('Button1').getElementsByTagName('a')[0].onclick();
+                }
+            }
+        };
+        var myCodeMirrors = {};
     </script>
 HEREDOC;
-    $modx->Event->output($output);
 }
+
+if (!$tvMode) {
+    $elements = array($textarea_name);
+}
+
+if (('none' == $rte) && $mode && $elements !== NULL) {
+    foreach ($elements as $el) {
+        $output .= "
+    <script>
+        var foldFunc = CodeMirror.newFoldFunction(CodeMirror.tagRangeFinder);
+        var myTextArea = document.getElementsByName('{$el}')[0];
+        myCodeMirrors['{$el}'] = (CodeMirror.fromTextArea(myTextArea, config));
+        // reset onchange tab
+        $$('.tab-row .tab').addEvents({
+                click: function() {
+                    myCodeMirrors['{$el}'].refresh();
+                }
+        });
+        // get data in localStorage
+        if ('true' == localStorage['cm_fullScreen_{$object_id}']){
+            setFullScreen(myCodeMirrors['{$el}'], !isFullScreen(myCodeMirrors['{$el}']));
+            myCodeMirrors['{$el}'].hasFocus();
+        }
+        if (localStorage['history_{$object_id}'] !== undefined){
+            var cmHistory = JSON.parse(localStorage['history_{$object_id}']);
+            myCodeMirrors['{$el}'].doc.setHistory(cmHistory);
+        }
+        // add event
+        myCodeMirrors['{$el}'].on('gutterClick', function(cm, n) {
+            var info = cm.lineInfo(n);
+            foldFunc(cm, n);
+            cm.setGutterMarker(n, 'breakpoints', info.gutterMarkers ? null : makeMarker('+'));
+        });
+        myCodeMirrors['{$el}'].on('change', function(cm, n) {
+            var cmHistory = myCodeMirrors['{$el}'].doc.getHistory();
+            localStorage['history_{$object_id}'] = JSON.stringify(cmHistory);
+            documentDirty=true;
+        });
+
+        (function() {
+            var tId = setInterval(function() {
+                if (document.readyState == 'complete')
+                    onComplete();
+            }, 11);
+            function onComplete() {
+                clearInterval(tId);
+                myCodeMirrors['{$el}'].refresh();
+            };
+        })();
+    </script>\n";
+    };
+};
+
+$modx->Event->output($output);

--- a/assets/plugins/tinymce/js/tinymce.linklist.php
+++ b/assets/plugins/tinymce/js/tinymce.linklist.php
@@ -269,14 +269,11 @@ class LINKLIST
 			"sc.published=1 AND sc.deleted=0 AND sc.id='{$doc_id}'"
 			);
 		$resourceArray = $modx->db->makeArray($result);
-		
-		// If we have got this far, it must not have been cached already, so lets do it now.
-		$page_cache[$doc_id] = $resourceArray[0];
-	
+
     		if (isset($resourceArray[0]))
 		{
-		$page_cache[$doc_id] = $resourceArray[0];
-		return $resourceArray[0];
+                    $page_cache[$doc_id] = $resourceArray[0];
+                    return $resourceArray[0];
 		}
 	    return;
 	}


### PR DESCRIPTION
- @dmi3yy modxRTEbridge is ready now. I thought adding to assets/lib/ makes sense.
- Richtext-TVs recognize now "editor"-param. Themes can be switched via "theme"-param. This way multiple editors on the same page are possible. Tested with
  - 2x **Codemirror** (TV-option: `{"editor":"Codemirror"}` ) + `[*content*]` switched to Codemirror
  - TinyMCE4 `{"editor":"TinyMCE4"}`
  - TinyMCE4 `{"editor":"TinyMCE4","theme":"creative"}`
  - TinyMCE4 `{"editor":"TinyMCE4","theme":"mini"}`
  - CKEditor4 `{"editor":"CKEditor4"}`
  - CKEditor4 `{"editor":"CKEditor4","theme":"mini"}`
  - mixing Tiny v3 and v4 on the same page was not possible due to JS-conflicts ;-)

![multipleeditors](https://cloud.githubusercontent.com/assets/8569221/13732024/8b29156a-e978-11e5-8c68-faadf0e917ba.png)

- added modxRTEbridge to assets/lib, supporting also inline-mode / frontpage-editing with Tiny4 now -> https://github.com/extras-evolution/tinymce4-for-modx-evo/pull/1#issuecomment-196080437

![tinyinline](https://cloud.githubusercontent.com/assets/8569221/13732043/28ec2bc0-e979-11e5-8bc0-e1e6c95f916e.png)
