### PR TITLE
Added explicit document root to $phpThumb

### DIFF
--- a/assets/snippets/phpthumb/snippet.phpthumb.php
+++ b/assets/snippets/phpthumb/snippet.phpthumb.php
@@ -53,6 +53,7 @@ if (!file_exists($outputFilename)) {
     require_once MODX_BASE_PATH.'assets/snippets/phpthumb/phpthumb.class.php';
     $phpThumb = new phpthumb();
     $phpThumb->config_temp_directory = $tmpFolder;
+    $phpThumb->config_document_root = MODX_BASE_PATH;
     $phpThumb->setSourceFilename(MODX_BASE_PATH . $input);
     foreach ($params as $key => $value) {
         $phpThumb->setParameter($key, $value);


### PR DESCRIPTION
This prevents errors while saving images when the site is installed to a virtual document root.