### PR TITLE
Fix: Display nothing instead of "Array" for none-existing chunks

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1039,7 +1039,7 @@ class DocumentParser {
             $ph = $this->_snipParamsToArray($snip_call['params']);
             
             $value = $this->getChunk($key);
-            $value = $this->parseText($ph,$value,'[+','+]','hasModifier');
+            $value = $value !== null ? $this->parseText($ph,$value,'[+','+]','hasModifier') : '';
             
             $replace[$i] = $value;
         }


### PR DESCRIPTION
In earlier versions none-existing chunks were rendered to an empty string, but today I noticed it gets rendered displaying the word "Array".