### PR TITLE
#699, #701

### DIFF
--- a/assets/snippets/wayfinder/wayfinder.inc.php
+++ b/assets/snippets/wayfinder/wayfinder.inc.php
@@ -40,7 +40,7 @@ class Wayfinder {
 				'[+wf.subitemcount+]',
 				'[+wf.refid+]',
 				'[+wf.menuindex+]',
-		'[+wf.iterator+]'
+				'[+wf.iterator+]'
 			),
 			'wrapperLevel' => array(
 				'[+wf.wrapper+]',
@@ -248,12 +248,15 @@ class Wayfinder {
 		//Load row values into placholder array
 		$charset = $modx->config['modx_charset'];
 		if ($this->_config['entityEncode']) {
-			$phArray = array($useSub,$useClass,$classNames,$resource['link'],htmlspecialchars($resource['title'], ENT_COMPAT, $charset),htmlspecialchars($resource['linktext'], ENT_COMPAT, $charset),$useId,$resource['alias'],$resource['link_attributes'],$resource['id'],htmlspecialchars($resource['introtext'], ENT_COMPAT, $charset),htmlspecialchars($resource['description'], ENT_COMPAT, $charset),$numChildren,$refid);
+			$phArray = array($useSub,$useClass,$classNames,$resource['link'],htmlspecialchars($resource['title'], ENT_COMPAT, $charset),htmlspecialchars($resource['linktext'], ENT_COMPAT, $charset),$useId,$resource['alias'],$resource['link_attributes'],$resource['id'],htmlspecialchars($resource['introtext'], ENT_COMPAT, $charset),htmlspecialchars($resource['description'], ENT_COMPAT, $charset));
 		} else {
-			$phArray = array($useSub,$useClass,$classNames,$resource['link'],$resource['title'],$resource['linktext'],$useId,$resource['alias'],$resource['link_attributes'],$resource['id'],$resource['introtext'],$resource['description'],$numChildren,$refid);
+			$phArray = array($useSub,$useClass,$classNames,$resource['link'],$resource['title'],$resource['linktext'],$useId,$resource['alias'],$resource['link_attributes'],$resource['id'],$resource['introtext'],$resource['description']);
 		}
-	//add iterator in phArray
-	$phArray[] = $curNum;
+		$phArray[] = $numChildren;
+		$phArray[] = $refid;
+		$phArray[] = $resource['menuindex'];
+		$phArray[] = $curNum;
+
 		$usePlaceholders = $this->placeHolders['rowLevel'];
 		//Add document variables to the placeholder array
 		foreach ($resource as $dvName => $dvVal) {

--- a/assets/templates/help/version_notices/1.1.1.php
+++ b/assets/templates/help/version_notices/1.1.1.php
@@ -50,3 +50,11 @@ Sub page
 		<p>Controls the display of 2 new buttons in resource-tree and grants/blocks access to KCFinder. More infos at <a href="https://github.com/modxcms/evolution/issues/681" target="_blank">Github #681</a></p>
 	</li>
 </ul>
+
+<h3 style="text-decoration: underline;">Template-Variables</h3>
+<ul>
+	<li><strong>@BINDINGS providing TV-values</strong>
+		<p>[+tv_name+] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given (set a reasonable default-value to avoid errors). More infos at <a href="https://github.com/modxcms/evolution/issues/699" target="_blank">Github #699</a>. Example:</p>
+		<pre>@SELECT name,value FROM xxx WHERE yyy = [+tv_name+]</pre>
+	</li>
+</ul>

--- a/assets/templates/help/version_notices/1.1.1.php
+++ b/assets/templates/help/version_notices/1.1.1.php
@@ -2,31 +2,31 @@
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
 ?>
 <p></p>
-<h3 style="text-decoration: underline;">Resource-Tree</h3>
+<h1>Resource-Tree</h1>
 <ul>
-	<li><strong>Moved "Sort menuindex" from DocManager to Resource-tree (#618, #636)</strong>
+	<li><strong>Moved "Sort menuindex" from DocManager to Resource-tree (<a href="https://github.com/modxcms/evolution/issues/618" target="_blank">#618</a>, <a href="https://github.com/modxcms/evolution/issues/636" target="_blank">#636</a>)</strong>
 		<p><u>Sort Resources in Root:</u> Click Button "Sort menu index" on top of resource-tree<br/>
 			<u>Sort Resources of Parent Resource:</u> Right mouse-click on parent, then choose "Sort menu index"
 		</p>
 	</li>
-	<li><strong>New "Manage Elements" Buttons (#669)</strong>
+	<li><strong>New "Manage Elements" Buttons (<a href="https://github.com/modxcms/evolution/issues/669" target="_blank">#669</a>)</strong>
 		<p>You can quick-access elements, files and images now directly from ressource-tree. Use Shift-Mouseclick to open multiple windows/elements.</p>
 	</li>
-	<li><strong>Remember last sort-options (#618, #636)</strong>
-		<p>The ressource-tree stores now the last set sort-options per user to database (Sort by, Asc/Desc, Display-Name). At manager log-in, last settings per user gets restored.</p>
+	<li><strong>Remember last sort-options (<a href="https://github.com/modxcms/evolution/issues/618" target="_blank">#618</a>, <a href="https://github.com/modxcms/evolution/issues/636" target="_blank">#636</a>)</strong>
+		<p>The ressource-tree stores now the last set sort-options per user to database (Sort by, Asc/Desc, Display-Name). At manager log-in, last settings of each user get restored.</p>
 	</li>
 </ul>
 
-<h3 style="text-decoration: underline;">MODX Tags</h3>
+<h1>MODX Tags</h1>
 <ul>
 	<li><strong>New Modifiers/Filters in Core (PHx)</strong>
-		<p>Can be disabled in MODX-configuration. More infos at <a href="https://github.com/modxcms/evolution/issues/623" target="_blank">Github #623</a></p>
+		<p>Can be disabled in MODX-configuration. More infos at <a href="https://github.com/modxcms/evolution/issues/623" target="_blank">#623</a></p>
 	</li>
 	<li><strong>Snippet - Shortcut param = true</strong>
 		<p>[[snippetName?param1&amp;param2]] will automatically be handled as [[snippetName?param1=`1`&amp;param2=`1`]] while param=`` will still be handled as empty value.</p>
 	</li>
 	<li><strong>New Conditional Tags / Modifiers</strong>
-		<p>Can be enabled/disabled via Configuration -> "Enable Filters". More examples at <a href="https://github.com/modxcms/evolution/issues/622" target="_blank">Github #622</a> and <a href="https://github.com/modxcms/evolution/issues/623" target="_blank">Github #623</a>. Example:</p>
+		<p>Can be enabled/disabled via Configuration -> "Enable Filters". More examples at <a href="https://github.com/modxcms/evolution/issues/622" target="_blank">#622</a> and <a href="https://github.com/modxcms/evolution/issues/623" target="_blank">#623</a>. Example:</p>
 		<pre>[*longtitle:ifempty=[*pagetitle*]*]</pre>
 		<pre>&lt;!--@IF:[*id:is('[(site_start)]')*]>
 Top page
@@ -36,37 +36,36 @@ Sub page
 	</li>
 
 	<li><strong>New Comment Tag</strong>
-		<p>Comment-Tags will be completely removed from output. More infos at <a href="https://github.com/modxcms/evolution/issues/680" target="_blank">Github #680</a>. Example:</p>
+		<p>Comment-Tags will be completely removed from output. More infos at <a href="https://github.com/modxcms/evolution/issues/680" target="_blank">#680</a>. Example:</p>
 		<pre>&lt;!--@- This is a comment -@--&gt;</pre>
 		<pre>&lt;!--@- Or HTML-Code / Snippets etc you want to disable temporarily -@--&gt;</pre>
 	</li>
 
 	<li><strong>New Chunk Parameters</strong>
-		<p>It is possible to pass properties/values to a chunk. More infos at <a href="https://github.com/modxcms/evolution/issues/625" target="_blank">Github #625</a>. Example:</p>
+		<p>It is possible to pass properties/values to a chunk. More infos at <a href="https://github.com/modxcms/evolution/issues/625" target="_blank">#625</a>. Example:</p>
 		<strong>Chunk:</strong>
 		<pre>
-&lt;h3&gt;[+title+]&lt;/h3&gt;
-&lt;p&gt;[+body+]&lt;/p&gt;
-		</pre>
+&lt;h1&gt;[+title+]&lt;/h1&gt;
+&lt;p&gt;[+body+]&lt;/p&gt;</pre>
 		<strong>Call:</strong>
 		<pre>{{chunkName?title='First post'&body='Hello World!'}}</pre>
 	</li>
 </ul>
 
-<h3 style="text-decoration: underline;">New Manager Roles</h3>
+<h1>New Manager Roles</h1>
 <ul>
 	<li><strong>change_resourcetype</strong>
-		<p>A user with this permission can change resource-type (webpage/weblink). More infos at <a href="https://github.com/modxcms/evolution/issues/531" target="_blank">Github #531</a></p>
+		<p>A user with this permission can change resource-type (webpage/weblink). More infos at <a href="https://github.com/modxcms/evolution/issues/531" target="_blank">#531</a></p>
 	</li>
 	<li><strong>assets_images, assets_files</strong>
-		<p>Controls the display of 2 new buttons in resource-tree and grants/blocks access to KCFinder. More infos at <a href="https://github.com/modxcms/evolution/issues/681" target="_blank">Github #681</a></p>
+		<p>Controls the display of 2 new buttons in resource-tree and grants/blocks access to KCFinder. More infos at <a href="https://github.com/modxcms/evolution/issues/681" target="_blank">#681</a></p>
 	</li>
 </ul>
 
-<h3 style="text-decoration: underline;">Template-Variables</h3>
+<h1>Template-Variables</h1>
 <ul>
 	<li><strong>@BINDINGS providing TV-values</strong>
-		<p>[+tv_name+] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given (set a reasonable default-value to avoid errors). More infos at <a href="https://github.com/modxcms/evolution/issues/699" target="_blank">Github #699</a>. Example:</p>
+		<p>[+tv_name+] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given (set a reasonable default-value to avoid errors). More infos at <a href="https://github.com/modxcms/evolution/issues/699" target="_blank">#699</a>. Example:</p>
 		<pre>@SELECT name,value FROM xxx WHERE yyy = [+tv_name+]</pre>
 	</li>
 </ul>

--- a/assets/templates/help/version_notices/1.1.1.php
+++ b/assets/templates/help/version_notices/1.1.1.php
@@ -34,10 +34,22 @@ Top page
 Sub page
 <@ENDIF--&gt;</pre>
 	</li>
+
 	<li><strong>New Comment Tag</strong>
 		<p>Comment-Tags will be completely removed from output. More infos at <a href="https://github.com/modxcms/evolution/issues/680" target="_blank">Github #680</a>. Example:</p>
 		<pre>&lt;!--@- This is a comment -@--&gt;</pre>
 		<pre>&lt;!--@- Or HTML-Code / Snippets etc you want to disable temporarily -@--&gt;</pre>
+	</li>
+
+	<li><strong>New Chunk Parameters</strong>
+		<p>It is possible to pass properties/values to a chunk. More infos at <a href="https://github.com/modxcms/evolution/issues/625" target="_blank">Github #625</a>. Example:</p>
+		<strong>Chunk:</strong>
+		<pre>
+&lt;h3&gt;[+title+]&lt;/h3&gt;
+&lt;p&gt;[+body+]&lt;/p&gt;
+		</pre>
+		<strong>Call:</strong>
+		<pre>{{chunkName?title='First post'&body='Hello World!'}}</pre>
 	</li>
 </ul>
 

--- a/assets/templates/help/version_notices/1.1.1.php
+++ b/assets/templates/help/version_notices/1.1.1.php
@@ -65,7 +65,7 @@ Sub page
 <h1>Template-Variables</h1>
 <ul>
 	<li><strong>@BINDINGS providing TV-values</strong>
-		<p>[+tv_name+] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given (set a reasonable default-value to avoid errors). More infos at <a href="https://github.com/modxcms/evolution/issues/699" target="_blank">#699</a>. Example:</p>
-		<pre>@SELECT name,value FROM xxx WHERE yyy = [+tv_name+]</pre>
+		<p>[*tv_name*] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given (set a reasonable default-value to avoid errors). More infos at <a href="https://github.com/modxcms/evolution/issues/699" target="_blank">#699</a>. Example:</p>
+		<pre>@SELECT name,value FROM xxx WHERE yyy = [*tv_name*]</pre>
 	</li>
 </ul>

--- a/install/setup.sql
+++ b/install/setup.sql
@@ -821,9 +821,9 @@ REPLACE INTO `{PREFIX}user_attributes`
 
 
 REPLACE INTO `{PREFIX}user_roles` 
-(id,name,description,frames,home,view_document,new_document,save_document,publish_document,delete_document,empty_trash,action_ok,logout,help,messages,new_user,edit_user,logs,edit_parser,save_parser,edit_template,settings,credits,new_template,save_template,delete_template,edit_snippet,new_snippet,save_snippet,delete_snippet,edit_chunk,new_chunk,save_chunk,delete_chunk,empty_cache,edit_document,change_password,error_dialog,about,file_manager,save_user,delete_user,save_password,edit_role,save_role,delete_role,new_role,access_permissions,bk_manager,new_plugin,edit_plugin,save_plugin,delete_plugin,new_module,edit_module,save_module,exec_module,delete_module,view_eventlog,delete_eventlog,manage_metatags,edit_doc_metatags,new_web_user,edit_web_user,save_web_user,delete_web_user,web_access_permissions,view_unpublished,import_static,export_static,remove_locks,assets_images,assets_files) VALUES 
-(2,'Editor','Limited to managing content',1,1,1,1,1,1,1,0,1,1,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,1,0,1,1,1,1,1,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,1,0,0,1,1,1),
-(3,'Publisher','Editor with expanded permissions including manage users\, update Elements and site settings',1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,0,0,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,1,1,1,1,0,1,0,0,1,1,1);
+(id,name,description,frames,home,view_document,new_document,save_document,publish_document,delete_document,empty_trash,action_ok,logout,help,messages,new_user,edit_user,logs,edit_parser,save_parser,edit_template,settings,credits,new_template,save_template,delete_template,edit_snippet,new_snippet,save_snippet,delete_snippet,edit_chunk,new_chunk,save_chunk,delete_chunk,empty_cache,edit_document,change_password,error_dialog,about,file_manager,save_user,delete_user,save_password,edit_role,save_role,delete_role,new_role,access_permissions,bk_manager,new_plugin,edit_plugin,save_plugin,delete_plugin,new_module,edit_module,save_module,exec_module,delete_module,view_eventlog,delete_eventlog,manage_metatags,edit_doc_metatags,new_web_user,edit_web_user,save_web_user,delete_web_user,web_access_permissions,view_unpublished,import_static,export_static,remove_locks,assets_images,assets_files,change_resourcetype) VALUES
+(2,'Editor','Limited to managing content',1,1,1,1,1,1,1,0,1,1,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,1,0,1,1,1,1,1,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,1,0,0,1,1,1,1),
+(3,'Publisher','Editor with expanded permissions including manage users\, update Elements and site settings',1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,0,0,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,1,1,1,1,0,1,0,0,1,1,1,1);
 
 
 # ]]non-upgrade-able
@@ -935,8 +935,8 @@ INSERT IGNORE INTO `{PREFIX}system_settings`
 ('clean_uploaded_filename', '1');
 
 REPLACE INTO `{PREFIX}user_roles` 
-(id,name,description,frames,home,view_document,new_document,save_document,publish_document,delete_document,empty_trash,action_ok,logout,help,messages,new_user,edit_user,logs,edit_parser,save_parser,edit_template,settings,credits,new_template,save_template,delete_template,edit_snippet,new_snippet,save_snippet,delete_snippet,edit_chunk,new_chunk,save_chunk,delete_chunk,empty_cache,edit_document,change_password,error_dialog,about,file_manager,save_user,delete_user,save_password,edit_role,save_role,delete_role,new_role,access_permissions,bk_manager,new_plugin,edit_plugin,save_plugin,delete_plugin,new_module,edit_module,save_module,exec_module,delete_module,view_eventlog,delete_eventlog,manage_metatags,edit_doc_metatags,new_web_user,edit_web_user,save_web_user,delete_web_user,web_access_permissions,view_unpublished,import_static,export_static,remove_locks) VALUES 
-(1, 'Administrator', 'Site administrators have full access to all functions',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+(id,name,description,frames,home,view_document,new_document,save_document,publish_document,delete_document,empty_trash,action_ok,logout,help,messages,new_user,edit_user,logs,edit_parser,save_parser,edit_template,settings,credits,new_template,save_template,delete_template,edit_snippet,new_snippet,save_snippet,delete_snippet,edit_chunk,new_chunk,save_chunk,delete_chunk,empty_cache,edit_document,change_password,error_dialog,about,file_manager,save_user,delete_user,save_password,edit_role,save_role,delete_role,new_role,access_permissions,bk_manager,new_plugin,edit_plugin,save_plugin,delete_plugin,new_module,edit_module,save_module,exec_module,delete_module,view_eventlog,delete_eventlog,manage_metatags,edit_doc_metatags,new_web_user,edit_web_user,save_web_user,delete_web_user,web_access_permissions,view_unpublished,import_static,export_static,remove_locks,assets_images,assets_files,change_resourcetype) VALUES 
+(1, 'Administrator', 'Site administrators have full access to all functions',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
 
 
 # 1 - "Parser Service Events", 2 -  "Manager Access Events", 3 - "Web Access Service Events", 4 - "Cache Service Events", 5 - "Template Service Events", 6 - Custom Events
@@ -1111,7 +1111,10 @@ UPDATE `{PREFIX}user_roles` SET
 	import_static = 1,
 	export_static = 1,
 	empty_trash = 1,
-	remove_locks = 1
+	remove_locks = 1,
+  assets_images = 1,
+  assets_files = 1,
+  change_resourcetype = 1
 	WHERE `id`=1;
 
 

--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -779,11 +779,12 @@ $page=isset($_REQUEST['page'])?(int)$_REQUEST['page']:'';
                 $rs = $modx->db->select($field,$from,$where,'tvtpl.rank,tv.rank, tv.id');
                 $limit = $modx->db->getRecordCount($rs);
                 if ($limit > 0) {
+                	$tvsArray = $modx->db->makeArray($rs,'name');
                     echo "\t".'<table style="position:relative;" border="0" cellspacing="0" cellpadding="3" width="96%">'."\n";
                     require_once(MODX_MANAGER_PATH.'includes/tmplvars.inc.php');
                     require_once(MODX_MANAGER_PATH.'includes/tmplvars.commands.inc.php');
                     $i = 0;
-                    while ($row = $modx->db->getRow($rs)) {
+                    foreach ($tvsArray as $row) {
                         // Go through and display all Template Variables
                         if ($row['type'] == 'richtext' || $row['type'] == 'htmlarea') {
                             // determine TV-options
@@ -818,7 +819,7 @@ $page=isset($_REQUEST['page'])?(int)$_REQUEST['page']:'';
                         echo "\t\t",'<tr style="height: 24px;"><td align="left" valign="top" width="150"><span class="warning">',$row['caption'].$tvName,"</span>\n",
                              "\t\t\t",$tvDescription,$tvInherited,"</td>\n",
                              "\t\t\t",'<td valign="top" style="position:relative;',($row['type'] == 'date' ? '' : ''),'">',"\n",
-                             "\t\t\t",renderFormElement($row['type'], $row['id'], $row['default_text'], $row['elements'], $tvPBV, '', $row),"\n",
+                             "\t\t\t",renderFormElement($row['type'], $row['id'], $row['default_text'], $row['elements'], $tvPBV, '', $row, $tvsArray),"\n",
                              "\t\t</td></tr>\n";
                     }
                     echo "\t</table>\n";

--- a/manager/includes/extenders/dbapi.mysql.class.inc.php
+++ b/manager/includes/extenders/dbapi.mysql.class.inc.php
@@ -605,14 +605,17 @@ class DBAPI {
    *          was passed
    * @param: $rs Recordset to be packaged into an array
    */
-   function makeArray($rs=''){
-      if(!$rs) return false;
-      $rsArray = array();
-      while ($row = $this->getRow($rs)) {
-            $rsArray[] = $row;
-      }
-      return $rsArray;
-   }
+	function makeArray($rs='',$index=false){
+		if (!$rs) return false;
+		$rsArray = array();
+		$iterator = 0;
+		while ($row = $this->getRow($rs)) {
+			$returnIndex = $index !== false && isset($row[$index]) ? $row[$index] : $iterator;
+			$rsArray[$returnIndex] = $row;
+			$iterator++;
+		}
+		return $rsArray;
+	}
    
    /**
     * @name	getVersion

--- a/manager/includes/extenders/dbapi.mysqli.class.inc.php
+++ b/manager/includes/extenders/dbapi.mysqli.class.inc.php
@@ -382,11 +382,14 @@ class DBAPI {
 		}
 	}
 
-	function makeArray($rs=''){
+	function makeArray($rs='',$index=false){
 		if (!$rs) return false;
 		$rsArray = array();
+		$iterator = 0;
 		while ($row = $this->getRow($rs)) {
-			$rsArray[] = $row;
+			$returnIndex = $index !== false && isset($row[$index]) ? $row[$index] : $iterator; 
+			$rsArray[$returnIndex] = $row;
+			$iterator++;
 		}
 		return $rsArray;
 	}

--- a/manager/includes/tmplvars.commands.inc.php
+++ b/manager/includes/tmplvars.commands.inc.php
@@ -14,7 +14,7 @@ $BINDINGS = array (
     'DIRECTORY'
 );
 
-function ProcessTVCommand($value, $name = '', $docid = '', $src='docform') {
+function ProcessTVCommand($value, $name = '', $docid = '', $src='docform', $tvsArray = array()) {
     global $modx;
     $etomite = & $modx;
     $docid = intval($docid) ? intval($docid) : $modx->documentIdentifier;
@@ -27,6 +27,7 @@ function ProcessTVCommand($value, $name = '', $docid = '', $src='docform') {
     else {
         list ($cmd, $param) = ParseCommand($nvalue);
         $cmd = trim($cmd);
+        $param = parseTvValues($param, $tvsArray);
         switch ($cmd) {
             case "FILE" :
                 $output = ProcessFile(trim($param));
@@ -114,7 +115,7 @@ function ProcessTVCommand($value, $name = '', $docid = '', $src='docform') {
 
         }
         // support for nested bindings
-        return is_string($output) && ($output != $value) ? ProcessTVCommand($output, $name, $docid, $src) : $output;
+        return is_string($output) && ($output != $value) ? ProcessTVCommand($output, $name, $docid, $src, $tvsArray) : $output;
     }
 }
 
@@ -140,4 +141,18 @@ function ParseCommand($binding_string)
         }
     }
     return $binding_array;
+}
+
+// ParseTvValues
+function parseTvValues($param, $tvsArray)
+{
+	global $modx;
+	if (strpos($param, '[+') !== false) {
+		$matches = $modx->getTagsFromContent($param, '[+', '+]');
+		foreach ($matches[0] as $i=>$match) {
+			if(isset($tvsArray[ $matches[1][$i] ]))
+				$param = str_replace($match, $tvsArray[ $matches[1][$i] ]['value'], $param);
+		}
+	}
+	return $param;
 }

--- a/manager/includes/tmplvars.commands.inc.php
+++ b/manager/includes/tmplvars.commands.inc.php
@@ -150,8 +150,11 @@ function parseTvValues($param, $tvsArray)
 	if (strpos($param, '[+') !== false) {
 		$matches = $modx->getTagsFromContent($param, '[+', '+]');
 		foreach ($matches[0] as $i=>$match) {
-			if(isset($tvsArray[ $matches[1][$i] ]))
-				$param = str_replace($match, $tvsArray[ $matches[1][$i] ]['value'], $param);
+			if(isset($tvsArray[ $matches[1][$i] ])) {
+				$value = $tvsArray[ $matches[1][$i] ]['value'];
+				$value = $value === '' ? $tvsArray[ $matches[1][$i] ]['default_text'] : $value;
+				$param = str_replace($match, $value, $param);
+			}
 		}
 	}
 	return $param;

--- a/manager/includes/tmplvars.commands.inc.php
+++ b/manager/includes/tmplvars.commands.inc.php
@@ -143,16 +143,21 @@ function ParseCommand($binding_string)
     return $binding_array;
 }
 
-// ParseTvValues
+// Parse MODX Template-Variables
 function parseTvValues($param, $tvsArray)
 {
 	global $modx;
-	if (strpos($param, '[+') !== false) {
-		$matches = $modx->getTagsFromContent($param, '[+', '+]');
+	$tvsArray = array_merge($tvsArray, $modx->documentObject);
+	if (strpos($param, '[*') !== false) {
+		$matches = $modx->getTagsFromContent($param, '[*', '*]');
 		foreach ($matches[0] as $i=>$match) {
 			if(isset($tvsArray[ $matches[1][$i] ])) {
-				$value = $tvsArray[ $matches[1][$i] ]['value'];
-				$value = $value === '' ? $tvsArray[ $matches[1][$i] ]['default_text'] : $value;
+				if(is_array($tvsArray[ $matches[1][$i] ])) {
+					$value = $tvsArray[$matches[1][$i]]['value'];
+					$value = $value === '' ? $tvsArray[$matches[1][$i]]['default_text'] : $value;
+				} else {
+					$value = $tvsArray[ $matches[1][$i] ];
+				}
 				$param = str_replace($match, $value, $param);
 			}
 		}

--- a/manager/includes/tmplvars.inc.php
+++ b/manager/includes/tmplvars.inc.php
@@ -1,6 +1,6 @@
 <?php
 	// DISPLAY FORM ELEMENTS
-	function renderFormElement($field_type, $field_id, $default_text='', $field_elements = '', $field_value='', $field_style='', $row = array()) {
+	function renderFormElement($field_type, $field_id, $default_text='', $field_elements = '', $field_value='', $field_style='', $row = array(), $tvsArray = array()) {
 		global $modx;
 		global $_style;
 		global $_lang;
@@ -45,7 +45,7 @@
 					break;
 				case "dropdown": // handler for select boxes
 					$field_html .=  '<select id="tv'.$field_id.'" name="tv'.$field_id.'" size="1" onchange="documentDirty=true;">';
-					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform'));
+					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform',$tvsArray));
 					while (list($item, $itemvalue) = each ($index_list))
 					{
 						list($item,$itemvalue) =  (is_array($itemvalue)) ? $itemvalue : explode("==",$itemvalue);
@@ -56,7 +56,7 @@
 					break;
 				case "listbox": // handler for select boxes
 					$field_html .=  '<select id="tv'.$field_id.'" name="tv'.$field_id.'" onchange="documentDirty=true;" size="8">';	
-					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform'));
+					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform',$tvsArray));
 					while (list($item, $itemvalue) = each ($index_list))
 					{
 						list($item,$itemvalue) =  (is_array($itemvalue)) ? $itemvalue : explode("==",$itemvalue);
@@ -68,7 +68,7 @@
 				case "listbox-multiple": // handler for select boxes where you can choose multiple items
 					$field_value = explode("||",$field_value);
 					$field_html .=  '<select id="tv'.$field_id.'" name="tv'.$field_id.'[]" multiple="multiple" onchange="documentDirty=true;" size="8">';
-					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform'));
+					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform',$tvsArray));
 					while (list($item, $itemvalue) = each ($index_list))
 					{
 						list($item,$itemvalue) =  (is_array($itemvalue)) ? $itemvalue : explode("==",$itemvalue);
@@ -92,7 +92,7 @@
 					break;
 				case "checkbox": // handles check boxes
 					$field_value = !is_array($field_value) ? explode("||",$field_value) : $field_value;
-					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform'));
+					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform',$tvsArray));
 					static $i=0;
 					while (list($item, $itemvalue) = each ($index_list))
 					{
@@ -103,7 +103,7 @@
 					}
 					break;
 				case "option": // handles radio buttons
-					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform'));
+					$index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id,'','tvform',$tvsArray));
 					static $i=0;
 					while (list($item, $itemvalue) = each ($index_list))
 					{

--- a/manager/media/style/MODxCarbon/style.css
+++ b/manager/media/style/MODxCarbon/style.css
@@ -1738,3 +1738,9 @@ li.breadcrumbs__li_current {
 	font-weight: bold;
 }
 /* end breadcrumbs */
+
+/* STYLES FOR HELP */
+#helpPane h3 { font-weight:bold; }
+#helpPane li:not(:first-child) > strong { margin-top:1.4em; }
+#helpPane li > strong { display:block; font-size:14px; }
+#helpPane pre { font-size:12px; border:1px solid #888; padding:1em; }

--- a/manager/media/style/MODxCarbon/style.css
+++ b/manager/media/style/MODxCarbon/style.css
@@ -1740,7 +1740,7 @@ li.breadcrumbs__li_current {
 /* end breadcrumbs */
 
 /* STYLES FOR HELP */
-#helpPane h3 { font-weight:bold; }
+#helpPane h1 { font-size:20px; display:block; border-bottom:1px solid #888; margin-bottom:1em; font-weight:bold; }
 #helpPane li:not(:first-child) > strong { margin-top:1.4em; }
 #helpPane li > strong { display:block; font-size:14px; }
 #helpPane pre { font-size:12px; border:1px solid #888; padding:1em; }

--- a/manager/media/style/MODxRE/style.css
+++ b/manager/media/style/MODxRE/style.css
@@ -2584,3 +2584,9 @@ form select {
 .sectionBody th {
   padding: 3px 5px;
 }
+
+/* STYLES FOR HELP */
+#helpPane h3 { font-weight:bold; }
+#helpPane li:not(:first-child) > strong { margin-top:1.4em; }
+#helpPane li > strong { display:block; font-size:14px; }
+#helpPane pre { font-size:12px; border:1px solid #888; padding:1em; }

--- a/manager/media/style/MODxRE/style.css
+++ b/manager/media/style/MODxRE/style.css
@@ -2586,7 +2586,7 @@ form select {
 }
 
 /* STYLES FOR HELP */
-#helpPane h3 { font-weight:bold; }
+#helpPane h1 { font-size:20px; display:block; border-bottom:1px solid #888; margin-bottom:1em; font-weight:bold; }
 #helpPane li:not(:first-child) > strong { margin-top:1.4em; }
 #helpPane li > strong { display:block; font-size:14px; }
 #helpPane pre { font-size:12px; border:1px solid #888; padding:1em; }


### PR DESCRIPTION
- Fix Wayfinder #701 
- #699: Allow using TV-values in @bindings like  
  `@SELECT name,value FROM xxx WHERE yyy = [+tv_name+]`  
  [+tv_name+] will be replaced by its value taken from actual resource. Beware of SQL-Errors in case no or wrong value is given..
