### PR TITLE
Action 990 for calling modxapi.ajax inside Manager, Dashboard-Buttons "Delete, Publish" ajaxified

### DIFF
--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -164,7 +164,7 @@ else {
                 title="' . $_lang["undelete_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=delete&amp;value=' . $content['id'] . '" target="main"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
             }
         }
-	    if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
+	    if($modx->hasPermission('save_document') && $modx->hasPermission('publish_document')) {
             if ($content['deleted'] == "1" AND $content['published'] == 0) {
                 $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
             } else if ($content['deleted'] == "1" AND $content['published'] == 1) {

--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -319,6 +319,8 @@ if (is_array($evtOut)) {
     $modx->setPlaceholder('OnManagerWelcomeRender', $output);
 }
 
+$modx->setPlaceholder('confirm_msg', $_lang['are_you_sure']);
+
 // load template
 if (!isset($modx->config['manager_welcome_tpl']) || empty($modx->config['manager_welcome_tpl'])) {
     $modx->config['manager_welcome_tpl'] = MODX_MANAGER_PATH . 'media/style/common/welcome.tpl';

--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -135,7 +135,7 @@ else {
         $editedbyu = $modx->getUserInfo($editedby);
         $html .= '<tr><td data-toggle="collapse" data-target=".collapse' . $content['id'] . '">
       
-        <span class="label label-info">' . $content['id'] . '</span></td><td>';
+        <span class="label label-info">' . $content['id'] . '</span></td><td class="resourceTitle">';
         if ($content['deleted'] == 1) {
             $html .= '<a class="deleted" ';
         } else if ($content['published'] == 0) {
@@ -144,32 +144,34 @@ else {
             $html .= '<a class="published" ';
         }
         $html .= 'title="' . $_lang["edit_resource"] . '" href="index.php?a=3&amp;id=' . $content['id'] . '">' . $content['pagetitle'] . '</a>' . '</td><td data-toggle="collapse" data-target=".collapse' . $content['id'] . '">' . $modx->toDateFormat($content['editedon'] + $server_offset_time) . '</td><td data-toggle="collapse" data-target=".collapse' . $content['id'] . '">' . $editedbyu['username'] . '</td>
-        <td style="text-align: right;">';
+        <td class="resourceActions" style="text-align: right;">';
         
         if ($modx->hasPermission('edit_document')) {
-            $html .= '<a class="btn btn-xs btn-success" title="' . $_lang["edit_resource"] . '" href="index.php?a=27&amp;id=' . $content['id'] . '"><i class="fa fa-edit fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-success btn-edit" title="' . $_lang["edit_resource"] . '" href="index.php?a=27&amp;id=' . $content['id'] . '"><i class="fa fa-edit fa-fw"></i></a> ';
         }
         
         if ($content['deleted'] == 1) {
-            $html .= '<a class="btn btn-xs btn-info disabled"  title="' . $_lang["preview_resource"] . '" target="_blank" href="../index.php?&amp;id=' . $content['id'] . '"><i class="fa fa-eye fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-info disabled btn-preview"  title="' . $_lang["preview_resource"] . '" target="_blank" href="../index.php?&amp;id=' . $content['id'] . '"><i class="fa fa-eye fa-fw"></i></a> ';
         } else {
-            $html .= '<a class="btn btn-xs btn-info"  title="' . $_lang["preview_resource"] . '" target="_blank" href="../index.php?&amp;id=' . $content['id'] . '"><i class="fa fa-eye fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-info btn-preview"  title="' . $_lang["preview_resource"] . '" target="_blank" href="../index.php?&amp;id=' . $content['id'] . '"><i class="fa fa-eye fa-fw"></i></a> ';
         }
         if ($modx->hasPermission('delete_document')) {
             if ($content['deleted'] == 0) {
-                $html .= '<a class="btn btn-xs btn-danger"  title="' . $_lang["delete_resource"] . '" href="index.php?a=6&amp;id=' . $content['id'] . '"><i class="fa fa-trash fa-fw"></i></a> ';
+                $html .= '<a class="btn btn-xs btn-danger btn-delete ajaxToggleDelete"
+                title="' . $_lang["delete_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=delete&amp;value=' . $content['id'] . '" target="main"><i class="fa fa-trash fa-fw"></i></a> ';
             } else {
-                $html .= '<a class="btn btn-xs btn-success"  title="' . $_lang["undelete_resource"] . '" href="index.php?a=63&amp;id=' . $content['id'] . '"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
+                $html .= '<a class="btn btn-xs btn-success btn-delete ajaxToggleDelete"
+                title="' . $_lang["undelete_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=delete&amp;value=' . $content['id'] . '" target="main"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
             }
         }
         if ($content['deleted'] == "1" AND $content['published'] == 0) {
-            $html .= '<a class="btn btn-xs btn-primary disabled"  title="' . $_lang["publish_resource"] . '" href="index.php?a=61&amp;id=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
         } else if ($content['deleted'] == "1" AND $content['published'] == 1) {
-            $html .= '<a class="btn btn-xs btn-primary disabled"  title="' . $_lang["publish_resource"] . '" href="index.php?a=61&amp;id=' . $content['id'] . '"><i class="fa fa-arrow-down fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down fa-fw"></i></a> ';
         } else if ($content['deleted'] == "0" AND $content['published'] == 0) {
-            $html .= '<a class="btn btn-xs btn-primary"  title="' . $_lang["publish_resource"] . '" href="index.php?a=61&amp;id=' . $content['id'] . '"><i class="fa fa-arrow-up  fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-primary btn-publish ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up  fa-fw"></i></a> ';
         } else {
-            $html .= '<a class="btn btn-xs btn-warning"  title="' . $_lang["unpublish_resource"] . '" href="index.php?a=62&amp;id=' . $content['id'] . '"><i class="fa fa-arrow-down  fa-fw"></i></a> ';
+            $html .= '<a class="btn btn-xs btn-warning btn-publish ajaxTogglePublish"  title="' . $_lang["unpublish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down  fa-fw"></i></a> ';
         }
         $html .= '<button class="btn btn-xs btn-default btn-expand btn-action" title="' . $_lang["resource_overview"] . '" data-toggle="collapse" data-target=".collapse' . $content['id'] . '"><i class="fa fa-info" aria-hidden="true"></i></button></td></tr><tr><td colspan="6" class="hiddenRow"><div class="resource-overview-accordian collapse collapse' . $content['id'] . '"><div class="overview-body small"><ul>        
 <li><b>' . $_lang["long_title"] . '</b>: ';

--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -164,7 +164,7 @@ else {
                 title="' . $_lang["undelete_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=delete&amp;value=' . $content['id'] . '" target="main"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
             }
         }
-        if ($modx->hasPermission('edit_document')) {
+	    if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
             if ($content['deleted'] == "1" AND $content['published'] == 0) {
                 $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
             } else if ($content['deleted'] == "1" AND $content['published'] == 1) {

--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -164,14 +164,16 @@ else {
                 title="' . $_lang["undelete_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=delete&amp;value=' . $content['id'] . '" target="main"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
             }
         }
-        if ($content['deleted'] == "1" AND $content['published'] == 0) {
-            $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
-        } else if ($content['deleted'] == "1" AND $content['published'] == 1) {
-            $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down fa-fw"></i></a> ';
-        } else if ($content['deleted'] == "0" AND $content['published'] == 0) {
-            $html .= '<a class="btn btn-xs btn-primary btn-publish ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up  fa-fw"></i></a> ';
-        } else {
-            $html .= '<a class="btn btn-xs btn-warning btn-publish ajaxTogglePublish"  title="' . $_lang["unpublish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down  fa-fw"></i></a> ';
+        if ($modx->hasPermission('edit_document')) {
+            if ($content['deleted'] == "1" AND $content['published'] == 0) {
+                $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up fa-fw"></i></a> ';
+            } else if ($content['deleted'] == "1" AND $content['published'] == 1) {
+                $html .= '<a class="btn btn-xs btn-primary btn-publish disabled ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down fa-fw"></i></a> ';
+            } else if ($content['deleted'] == "0" AND $content['published'] == 0) {
+                $html .= '<a class="btn btn-xs btn-primary btn-publish ajaxTogglePublish"  title="' . $_lang["publish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-up  fa-fw"></i></a> ';
+            } else {
+                $html .= '<a class="btn btn-xs btn-warning btn-publish ajaxTogglePublish"  title="' . $_lang["unpublish_resource"] . '" href="index.php?a=990&amp;api=resource&amp;action=publish&amp;value=' . $content['id'] . '"><i class="fa fa-arrow-down  fa-fw"></i></a> ';
+            }
         }
         $html .= '<button class="btn btn-xs btn-default btn-expand btn-action" title="' . $_lang["resource_overview"] . '" data-toggle="collapse" data-target=".collapse' . $content['id'] . '"><i class="fa fa-info" aria-hidden="true"></i></button></td></tr><tr><td colspan="6" class="hiddenRow"><div class="resource-overview-accordian collapse collapse' . $content['id'] . '"><div class="overview-body small"><ul>        
 <li><b>' . $_lang["long_title"] . '</b>: ';

--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -189,7 +189,7 @@ else {
             $html .= '' . $content['description'] . '</li> ';
         }
         $html .= '<li><b>' . $_lang["resource_summary"] . '</b>: ';
-        if ($content['resource_summary'] == "") {
+        if ($content['introtext'] == "") {
             $html .= '(<i>'.$_lang['not_set'].'</i>)';
         } else {   
             $html .= '' . $content['introtext'] . '</li> ';
@@ -201,7 +201,7 @@ else {
             $html .= '' . $_lang['resource'] . '</li>';
         }
         $html .= '<li><b>' . $_lang["resource_alias"] . '</b>: ';
-        if ($content['resource_alias'] == "") {
+        if ($content['alias'] == "") {
             $html .= '(<i>'.$_lang['not_set'].'</i>)';
         } else { 
            $html .= '' . $content['alias'] . '</li>';

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -2205,7 +2205,8 @@ class DocumentParser {
      * @param string $msg Message to show
      * @param string $url URL to redirect to
      */
-    function webAlertAndQuit($msg, $url= "") {
+    function webAlertAndQuit($msg, $url= "", $ajaxResponse=false) {
+        if($ajaxResponse) {	echo $msg; exit; }
         global $modx_manager_charset;
         if (substr(strtolower($url), 0, 11) == "javascript:") {
             $fnc = substr($url, 11);

--- a/manager/includes/lang/english.inc.php
+++ b/manager/includes/lang/english.inc.php
@@ -1336,3 +1336,5 @@ $_lang["which_browser_default_msg"]= "Choose the File Browser you prefer as defa
 $_lang["which_browser_title"]= "File Browser";
 $_lang["which_browser_msg"]= "You can choose a custom File Browser for this user. To use the System´s default Browser, leave it on &quot;Default&quot;.";
 $_lang["option_default"] = "Default";
+
+$_lang["are_you_sure"] = "Are you sure?";

--- a/manager/includes/modxapi.ajax.php
+++ b/manager/includes/modxapi.ajax.php
@@ -19,10 +19,8 @@ $key = $modx->db->escape($key);
 $value = $modx->db->escape($value);
 $lang = $modx->db->escape($lang);
 
-$str = '';
-
-$error = 'Saving not successful, check your system events-log. Important: Set "Allow root / udperms_allowroot" in configuration to on.';
-$success = false;
+$error = 'Unknown error';
+$ajaxResponse = true; // For processors & $modx->webAlertAndQuit()
 
 switch($api) {
 	case 'resource':
@@ -32,33 +30,28 @@ switch($api) {
 		$modx->doc->edit($value);
 		switch($action) {
 			case 'publish':
-				if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) { $error = $_lang["error_no_privileges"]; break; };  
 				$published = $modx->doc->get('published');
 				$str = $published == 0 ? 1 : 0;
-				if($value == $site_start && $str == 0) {
-					$error = 'Resource "site_start" cannot be unpublished';
+				if($str == 1) {
+					$_REQUEST['id'] = $value;
+					require_once(dirname(__FILE__) . '/../processors/publish_content.processor.php');
 				} else {
-					// Assure modResource does not rely on pub_date to re-publish a resource 
-					if($str == 0 && $modx->doc->get('pub_date') < time() + $server_offset_time) {
-						$modx->doc->set('pub_date', 0);
-						$modx->doc->set('publishedon', 0);
-					}
-					$modx->doc->set('published', $str);
-					$success = $modx->doc->save(true, true);
+					$_REQUEST['id'] = $value;
+					require_once(dirname(__FILE__) . '/../processors/unpublish_content.processor.php');
 				}
 				break;
 			case 'delete':
-				if (!$modx->hasPermission('delete_document')) { $error = $_lang["error_no_privileges"]; break; };
 				$deleted = $modx->doc->get('deleted');
 				$str = $deleted == 0 ? 1 : 0;
-				if($value == $site_start && $str == 1) {
-					$error = 'Resource "site_start" cannot be deleted';
+				if($str == 1) {
+					$_GET['id'] = $value; 
+					require_once(dirname(__FILE__) . '/../processors/delete_content.processor.php');
 				} else {
-					$modx->doc->set('deleted', $str);
-					$success = $modx->doc->save(true, true);
+					$_REQUEST['id'] = $value;
+					require_once(dirname(__FILE__) . '/../processors/undelete_content.processor.php');
 				}
 				break;
 		}
 }
 
-echo $success !== false ? $str : $error;
+echo isset($response) ? $response : $error;

--- a/manager/includes/modxapi.ajax.php
+++ b/manager/includes/modxapi.ajax.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * modxapi.ajax.php
+ * 
+ */
+if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
+
+require_once(dirname(__FILE__) . '/protect.inc.php');
+
+$api    = preg_replace('/[^A-Za-z0-9_\-\.\/]/', '', $_REQUEST['api']);
+$action = preg_replace('/[^A-Za-z0-9_\-\.\/]/', '', $_REQUEST['action']);
+$key    = preg_replace('/[^A-Za-z0-9_\-\.\/]/', '', $_REQUEST['key']);
+$value  = preg_replace('/[^A-Za-z0-9_\-\.\/]/', '', $_REQUEST['value']);
+$lang   = preg_replace('/[^A-Za-z0-9_\s\+\-\.\/]/', '', $_REQUEST['lang']);
+
+$api = $modx->db->escape($api);
+$action = $modx->db->escape($action);
+$key = $modx->db->escape($key);
+$value = $modx->db->escape($value);
+$lang = $modx->db->escape($lang);
+
+$str = '';
+
+$error = 'Saving not successful, check your system events-log. Important: Set "Allow root / udperms_allowroot" in configuration to on.';
+$success = false;
+
+switch($api) {
+	case 'resource':
+		include_once(MODX_BASE_PATH . "assets/lib/MODxAPI/modResource.php");
+		$value = intval($value);
+		$modx->doc = new modResource($modx);
+		$modx->doc->edit($value);
+		switch($action) {
+			case 'publish':
+				$published = $modx->doc->get('published');
+				$str = $published == 0 ? 1 : 0;
+				if($value == $site_start && $str == 0) {
+					$error = 'Resource "site_start" cannot be unpublished';
+				} else {
+					$modx->doc->set('published', $str);
+					$success = $modx->doc->save(true, true);
+				}
+				break;
+			case 'delete':
+				$deleted = $modx->doc->get('deleted');
+				$str = $deleted == 0 ? 1 : 0;
+				if($value == $site_start && $str == 1) {
+					$error = 'Resource "site_start" cannot be deleted';
+				} else {
+					$modx->doc->set('deleted', $str);
+					$success = $modx->doc->save(true, true);
+				}
+				break;
+		}
+}
+
+echo $success !== false ? $str : $error;

--- a/manager/includes/modxapi.ajax.php
+++ b/manager/includes/modxapi.ajax.php
@@ -32,6 +32,7 @@ switch($api) {
 		$modx->doc->edit($value);
 		switch($action) {
 			case 'publish':
+				if (!$modx->hasPermission('edit_document')) { $error = 'No permission'; break; };  
 				$published = $modx->doc->get('published');
 				$str = $published == 0 ? 1 : 0;
 				if($value == $site_start && $str == 0) {
@@ -47,6 +48,7 @@ switch($api) {
 				}
 				break;
 			case 'delete':
+				if (!$modx->hasPermission('delete_document')) { $error = 'No permission'; break; };
 				$deleted = $modx->doc->get('deleted');
 				$str = $deleted == 0 ? 1 : 0;
 				if($value == $site_start && $str == 1) {

--- a/manager/includes/modxapi.ajax.php
+++ b/manager/includes/modxapi.ajax.php
@@ -37,6 +37,11 @@ switch($api) {
 				if($value == $site_start && $str == 0) {
 					$error = 'Resource "site_start" cannot be unpublished';
 				} else {
+					// Assure modResource does not rely on pub_date to re-publish a resource 
+					if($str == 0 && $modx->doc->get('pub_date') < time() + $server_offset_time) {
+						$modx->doc->set('pub_date', 0);
+						$modx->doc->set('publishedon', 0);
+					}
 					$modx->doc->set('published', $str);
 					$success = $modx->doc->save(true, true);
 				}

--- a/manager/includes/modxapi.ajax.php
+++ b/manager/includes/modxapi.ajax.php
@@ -32,7 +32,7 @@ switch($api) {
 		$modx->doc->edit($value);
 		switch($action) {
 			case 'publish':
-				if (!$modx->hasPermission('edit_document')) { $error = 'No permission'; break; };  
+				if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) { $error = $_lang["error_no_privileges"]; break; };  
 				$published = $modx->doc->get('published');
 				$str = $published == 0 ? 1 : 0;
 				if($value == $site_start && $str == 0) {
@@ -48,7 +48,7 @@ switch($api) {
 				}
 				break;
 			case 'delete':
-				if (!$modx->hasPermission('delete_document')) { $error = 'No permission'; break; };
+				if (!$modx->hasPermission('delete_document')) { $error = $_lang["error_no_privileges"]; break; };
 				$deleted = $modx->doc->get('deleted');
 				$str = $deleted == 0 ? 1 : 0;
 				if($value == $site_start && $str == 1) {

--- a/manager/includes/tmplvars.commands.inc.php
+++ b/manager/includes/tmplvars.commands.inc.php
@@ -147,7 +147,7 @@ function ParseCommand($binding_string)
 function parseTvValues($param, $tvsArray)
 {
 	global $modx;
-	$tvsArray = array_merge($tvsArray, $modx->documentObject);
+	$tvsArray = is_array($modx->documentObject) ? array_merge($tvsArray, $modx->documentObject) : $tvsArray;
 	if (strpos($param, '[*') !== false) {
 		$matches = $modx->getTagsFromContent($param, '[*', '*]');
 		foreach ($matches[0] as $i=>$match) {

--- a/manager/index.php
+++ b/manager/index.php
@@ -343,7 +343,7 @@ switch ($action) {
 		include_once(includeFileProcessor("processors/publish_content.processor.php",$manager_theme));
 	break;
 	case 62:
-		// get the processor for publishing content
+		// get the processor for unpublishing content
 		include_once(includeFileProcessor("processors/unpublish_content.processor.php",$manager_theme));
 	break;
 	case 56:
@@ -954,6 +954,14 @@ switch ($action) {
 		//delete category
 		include_once(includeFileProcessor("processors/delete_category.processor.php",$manager_theme));
 	break;
+/********************************************************************/
+/* MODxAPI via Ajax                                                 */
+/********************************************************************/
+	case 990:
+		// call modxapi ajax include
+		ob_clean();
+		include_once(includeFileProcessor("includes/modxapi.ajax.php",$manager_theme));
+		break;
 /********************************************************************/
 /* default action: show not implemented message                     */
 /********************************************************************/

--- a/manager/media/style/MODxRE2/dashboard/js/evodashboard.js
+++ b/manager/media/style/MODxRE2/dashboard/js/evodashboard.js
@@ -8,11 +8,11 @@ function fnCreateGridster(page, states){
 	
 
 	/* force 1 column on mobile screen sizes */
-	if ($( window ).width() <= 480 || $( window ).width() == 840 ){
+	if ($( window ).width() <= 480){
 		var cols=1;
 		var offset=60;
 	} else {
-		var cols=4
+		var cols=4;
 		var offset=19;
 	}
 
@@ -48,7 +48,7 @@ function fnCreateGridster(page, states){
 				$.each(_positions, function(i,value){
 					_state=$('#'+ value.id).attr('data-state');
 					if(_state=='min'){
-						value.size_y=$('#'+ value.id).attr('data-sizey-old')
+						value.size_y=$('#'+ value.id).attr('data-sizey-old');
 						_positions[i]=value;
 					}
 				
@@ -99,7 +99,7 @@ function fnCreateGridster(page, states){
 		if(localdata_states){
 			$.each(localdata_states, function(i,value){
 				if(value){
-					if(value.panel == panel) localdata_states.splice(i, 1);		
+					if(value.panel == panel) localdata_states.splice(i, 1);
 				}
 			});
 		} else localdata_states=[];
@@ -134,7 +134,7 @@ function fnCreateGridster(page, states){
 
 	function _resize_gridster(){
 		gridster.resize_widget_dimensions({
-			widget_base_dimensions: [(((base_size*($( window ).width()/base_size))/cols)-offset), 50],
+			widget_base_dimensions: [(((base_size*($( window ).width()/base_size))/cols)-offset + 4), 50],
 			widget_margins: [5, 5],
 		});
 	}
@@ -146,6 +146,7 @@ function fnCreateGridster(page, states){
 	/* start welcome with fade in fx*/
 	setTimeout(function(){
 		$('.gridster').fadeIn('fast');
+        _resize_gridster();
 	}, 400);
 
 }

--- a/manager/media/style/MODxRE2/welcome.tpl
+++ b/manager/media/style/MODxRE2/welcome.tpl
@@ -166,6 +166,9 @@
   // Ajax-Button "Delete"  
   jQuery('.ajaxToggleDelete').click(function(e) {
       e.preventDefault();
+      r = confirm("[+confirm_msg+]");
+      if (r != true) return; 
+          
       var button = $(this); 
       jQuery.ajax({
           url: button.attr('href'),
@@ -199,6 +202,9 @@
   // Ajax-Button "Publish"  
   jQuery('.ajaxTogglePublish').click(function(e) {
       e.preventDefault();
+      r = confirm("[+confirm_msg+]");
+      if (r != true) return;
+      
       var button = $(this); 
       jQuery.ajax({
           url: button.attr('href'),

--- a/manager/media/style/MODxRE2/welcome.tpl
+++ b/manager/media/style/MODxRE2/welcome.tpl
@@ -161,8 +161,69 @@
   var localdata_position = JSON.parse(localStorage.getItem('[+site_name+]-evodashboard.grid'));
   var localdata_states = JSON.parse(localStorage.getItem('[+site_name+]-evodashboard.states'));
 
-
   fnCreateGridster('[+site_name+]-evodashboard.grid', '[+site_name+]-evodashboard.states');
+  
+  // Ajax-Button "Delete"  
+  jQuery('.ajaxToggleDelete').click(function(e) {
+      e.preventDefault();
+      var button = $(this); 
+      jQuery.ajax({
+          url: button.attr('href'),
+          type: 'GET'
+      })
+      .done(function(result) {
+          if(result == 0) {
+              // Resource is not deleted
+              button.closest('tr').find("td.resourceTitle > a").removeClass('deleted');
+              button.closest('tr').find("td.resourceActions > .btn-publish").removeClass('disabled');
+          } else if(result == 1) {
+              // Resource is deleted
+              button.closest('tr').find("td.resourceTitle > a").addClass('deleted');
+              button.closest('tr').find("td.resourceActions > .btn-publish").addClass('disabled');
+          } else {
+              // Error, nothing changed
+              alert(result);
+          }
+          top.mainMenu.reloadtree();
+      })
+      .fail(function(result) {
+          // Error, nothing changed
+          alert('Failed: '+result);
+      });
+  });
+    
+  // Ajax-Button "Publish"  
+  jQuery('.ajaxTogglePublish').click(function(e) {
+      e.preventDefault();
+      var button = $(this); 
+      jQuery.ajax({
+          url: button.attr('href'),
+          type: 'GET'
+      })
+      .done(function(result) {
+          if(result == 0) {
+              // Resource is not published
+              button.closest('tr').find("td.resourceTitle > a").removeClass('published');
+              button.closest('tr').find("td.resourceTitle > a").addClass('unpublished');
+              button.closest('tr').find("td.resourceActions > a.btn-publish > i").removeClass('fa-arrow-down');
+              button.closest('tr').find("td.resourceActions > a.btn-publish > i").addClass('fa-arrow-up');
+          } else if(result == 1) {
+              // Resource is published
+              button.closest('tr').find("td.resourceTitle > a").removeClass('unpublished');
+              button.closest('tr').find("td.resourceTitle > a").addClass('published');
+              button.closest('tr').find("td.resourceActions > a.btn-publish > i").addClass('fa-arrow-down');
+              button.closest('tr').find("td.resourceActions > a.btn-publish > i").removeClass('fa-arrow-up');
+          } else {
+              // Error, nothing changed
+              alert(result);
+          }
+          top.mainMenu.reloadtree();
+      })
+      .fail(function(result) {
+          // Error, nothing changed
+          alert('Failed: '+result);
+      });
+  });
 </script>
 
 <script type="text/javascript">        

--- a/manager/media/style/MODxRE2/welcome.tpl
+++ b/manager/media/style/MODxRE2/welcome.tpl
@@ -176,10 +176,14 @@
               // Resource is not deleted
               button.closest('tr').find("td.resourceTitle > a").removeClass('deleted');
               button.closest('tr').find("td.resourceActions > .btn-publish").removeClass('disabled');
+              button.closest('tr').find("td.resourceActions > a.btn-delete > i").removeClass('fa-arrow-circle-o-up');
+              button.closest('tr').find("td.resourceActions > a.btn-delete > i").addClass('fa-trash');
           } else if(result == 1) {
               // Resource is deleted
               button.closest('tr').find("td.resourceTitle > a").addClass('deleted');
               button.closest('tr').find("td.resourceActions > .btn-publish").addClass('disabled');
+              button.closest('tr').find("td.resourceActions > a.btn-delete > i").addClass('fa-arrow-circle-o-up');
+              button.closest('tr').find("td.resourceActions > a.btn-delete > i").removeClass('fa-trash');
           } else {
               // Error, nothing changed
               alert(result);

--- a/manager/processors/delete_content.processor.php
+++ b/manager/processors/delete_content.processor.php
@@ -1,12 +1,15 @@
 <?php
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
+
+$ajaxResponse = isset($ajaxResponse) ? $ajaxResponse : false;
+
 if(!$modx->hasPermission('delete_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+	$modx->webAlertAndQuit($_lang["error_no_privileges"], "", $ajaxResponse);
 }
 
 $id = isset($_GET['id'])? intval($_GET['id']) : 0;
 if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+	$modx->webAlertAndQuit($_lang["error_no_id"], "", $ajaxResponse);
 }
 
 /*******ищем родителя чтобы к нему вернуться********/
@@ -32,7 +35,7 @@ $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
 if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+	$modx->webAlertAndQuit($_lang["access_permission_denied"], "", $ajaxResponse);
 }
 
 function getChildren($parent) {
@@ -48,16 +51,16 @@ function getChildren($parent) {
 		// the document has children documents, we'll need to delete those too
 		while ($childid=$modx->db->getValue($rs)) {
 			if($childid==$site_start) {
-				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site start' document, and cannot be deleted. Please assign another document as your 'Site start' document and try again.");
+				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site start' document, and cannot be deleted. Please assign another document as your 'Site start' document and try again.", "", $ajaxResponse);
 			}
 			if($childid==$site_unavailable_page) {
-				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site unavailable page' document, and cannot be deleted. Please assign another document as your 'Site unavailable page' document and try again.");
+				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site unavailable page' document, and cannot be deleted. Please assign another document as your 'Site unavailable page' document and try again.", "", $ajaxResponse);
 			}
 			if($childid==$error_page) {
-				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site error page' document, and cannot be deleted. Please assign another document as your 'Site error page' document and try again.");
+				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site error page' document, and cannot be deleted. Please assign another document as your 'Site error page' document and try again.", "", $ajaxResponse);
 			}
 			if($childid==$unauthorized_page) {
-				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site unauthorized page' document, and cannot be deleted. Please assign another document as your 'Site unauthorized page' document and try again.");
+				$modx->webAlertAndQuit("The document you are trying to delete is a folder containing document {$childid}. This document is registered as the 'Site unauthorized page' document, and cannot be deleted. Please assign another document as your 'Site unauthorized page' document and try again.", "", $ajaxResponse);
 			}
 			$children[] = $childid;
 			getChildren($childid);
@@ -84,19 +87,19 @@ if(count($children)>0) {
 }
 
 if($site_start==$id){
-	$modx->webAlertAndQuit("Document is 'Site start' and cannot be deleted!");
+	$modx->webAlertAndQuit("Document is 'Site start' and cannot be deleted!", "", $ajaxResponse);
 }
 
 if($site_unavailable_page==$id){
-	$modx->webAlertAndQuit("Document is used as the 'Site unavailable page' and cannot be deleted!");
+	$modx->webAlertAndQuit("Document is used as the 'Site unavailable page' and cannot be deleted!", "", $ajaxResponse);
 }
 
 if($error_page==$id) {
-	$modx->webAlertAndQuit("Document is used as the 'Site error page' and cannot be deleted!");
+	$modx->webAlertAndQuit("Document is used as the 'Site error page' and cannot be deleted!", "", $ajaxResponse);
 }
 
 if($unauthorized_page==$id){
-	$modx->webAlertAndQuit("Document is used as the 'Site unauthorized page' and cannot be deleted!");
+	$modx->webAlertAndQuit("Document is used as the 'Site unauthorized page' and cannot be deleted!", "", $ajaxResponse);
 }
 
 // delete the document.
@@ -121,6 +124,10 @@ $_SESSION['itemname'] = $content['pagetitle'];
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?r=1&a=7&id=$pid&dv=1".$add_path;
-header($header);
+if(isset($ajaxResponse) && $ajaxResponse == true) {
+	$response = 1;
+} else {
+	$header = "Location: index.php?r=1&a=7&id=$pid&dv=1" . $add_path;
+	header($header);
+}
 ?>

--- a/manager/processors/publish_content.processor.php
+++ b/manager/processors/publish_content.processor.php
@@ -1,12 +1,15 @@
 <?php
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
+
+$ajaxResponse = isset($ajaxResponse) ? $ajaxResponse : false;
+
 if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+	$modx->webAlertAndQuit($_lang["error_no_privileges"], "", $ajaxResponse);
 }
 
 $id = isset($_REQUEST['id'])? intval($_REQUEST['id']) : 0;
 if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+	$modx->webAlertAndQuit($_lang["error_no_id"], "", $ajaxResponse);
 }
 
 /************webber ********/
@@ -31,7 +34,7 @@ $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
 if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+	$modx->webAlertAndQuit($_lang["access_permission_denied"], "", $ajaxResponse);
 }
 
 // update the document
@@ -55,10 +58,11 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-//$header="Location: index.php?r=1&id=$id&a=7";
-
-// webber
-$header="Location: index.php?r=1&id=$pid&a=7&dv=1".$add_path;
-
-header($header);
+// finished emptying cache - redirect
+if(isset($ajaxResponse) && $ajaxResponse == true) {
+	$response = 1;
+} else {
+	$header = "Location: index.php?r=1&id=$pid&a=7&dv=1" . $add_path;
+	header($header);
+}
 ?>

--- a/manager/processors/undelete_content.processor.php
+++ b/manager/processors/undelete_content.processor.php
@@ -1,12 +1,15 @@
 <?php 
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
-if(!$modx->hasPermission('delete_document')) {	
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+
+$ajaxResponse = isset($ajaxResponse) ? $ajaxResponse : false;
+
+if(!$modx->hasPermission('delete_document')) {
+	$modx->webAlertAndQuit($_lang["error_no_privileges"], "", $ajaxResponse);
 }
 
 $id = isset($_REQUEST['id'])? intval($_REQUEST['id']) : 0;
 if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+	$modx->webAlertAndQuit($_lang["error_no_id"], "", $ajaxResponse);
 }
 
 /************ webber ********/
@@ -30,14 +33,14 @@ $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
 if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+	$modx->webAlertAndQuit($_lang["access_permission_denied"], "", $ajaxResponse);
 }
 
 // get the timestamp on which the document was deleted.
 $rs = $modx->db->select('deletedon', $modx->getFullTableName('site_content'), "id='{$id}' AND deleted=1");
 $deltime = $modx->db->getValue($rs);
 if(!$deltime) {
-	$modx->webAlertAndQuit("Couldn't find document to determine it's date of deletion!");
+	$modx->webAlertAndQuit("Couldn't find document to determine it's date of deletion!", "", $ajaxResponse);
 }
 
 $children = array();
@@ -80,10 +83,13 @@ $modx->db->update(
 
 	// empty cache
 	$modx->clearCache('full');
-	// finished emptying cache - redirect
-	//$header="Location: index.php?r=1&a=7&id=$id&dv=1";
 
-// webber
-	$header="Location: index.php?r=1&a=7&id=$pid&dv=1".$add_path;
+
+// finished emptying cache - redirect
+if(isset($ajaxResponse) && $ajaxResponse == true) {
+	$response = 0;
+} else {
+	$header = "Location: index.php?r=1&a=7&id=$pid&dv=1" . $add_path;
 	header($header);
+}
 ?>

--- a/manager/processors/unpublish_content.processor.php
+++ b/manager/processors/unpublish_content.processor.php
@@ -1,12 +1,15 @@
 <?php
 if(IN_MANAGER_MODE!="true") die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the MODX Content Manager instead of accessing this file directly.");
+
+$ajaxResponse = isset($ajaxResponse) ? $ajaxResponse : false;
+
 if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+	$modx->webAlertAndQuit($_lang["error_no_privileges"], "", $ajaxResponse);
 }
 
 $id = isset($_REQUEST['id'])? intval($_REQUEST['id']) : 0;
 if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+	$modx->webAlertAndQuit($_lang["error_no_id"], "", $ajaxResponse);
 }
 
 /************webber ********/
@@ -21,7 +24,21 @@ $add_path=$sd.$sb.$pg;
 
 /***********************************/
 
+if($site_start==$id){
+	$modx->webAlertAndQuit("Document is 'Site start' and cannot be unpublished!", "", $ajaxResponse);
+}
 
+if($site_unavailable_page==$id){
+	$modx->webAlertAndQuit("Document is used as the 'Site unavailable page' and cannot be unpublished!", "", $ajaxResponse);
+}
+
+if($error_page==$id) {
+	$modx->webAlertAndQuit("Document is used as the 'Site error page' and cannot be unpublished!", "", $ajaxResponse);
+}
+
+if($unauthorized_page==$id){
+	$modx->webAlertAndQuit("Document is used as the 'Site unauthorized page' and cannot be unpublished!", "", $ajaxResponse);
+}
 
 // check permissions on the document
 include_once MODX_MANAGER_PATH . "processors/user_documents_permissions.class.php";
@@ -31,7 +48,7 @@ $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
 if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+	$modx->webAlertAndQuit($_lang["access_permission_denied"], "", $ajaxResponse);
 }
 
 // update the document
@@ -55,10 +72,11 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-//$header="Location: index.php?r=1&id=$id&a=7";
-
-// webber
-$header="Location: index.php?r=1&id=$pid&a=7&dv=1".$add_path;
-
-header($header);
+// finished emptying cache - redirect
+if(isset($ajaxResponse) && $ajaxResponse == true) {
+	$response = 0;
+} else {
+	$header = "Location: index.php?r=1&id=$pid&a=7&dv=1" . $add_path;
+	header($header);
+}
 ?>


### PR DESCRIPTION
I´m not sure if you guys like adding this idea to core. With this PR it is possible to click those 2 buttons without reloading the page. CSS-styles can be toggled as per server-answer (published/deleted = yes/no). The resource-tree also updates accordingly "in realtime".

![dash](https://cloud.githubusercontent.com/assets/8569221/19520558/ef6c027c-9610-11e6-9ab6-e1c7a50659c4.png)

