### PR TITLE
Update htaccess directive for apache 2.2 & 2.4

### DIFF
--- a/assets/cache/images/.htaccess
+++ b/assets/cache/images/.htaccess
@@ -1,2 +1,9 @@
-order deny,allow
-allow from all
+<IfModule !mod_authz_core.c>
+Order allow,deny
+Allow from all
+</IfModule>
+
+<IfModule mod_authz_core.c>
+## configuration for Apache 2.4
+Require all granted
+</IfModule>


### PR DESCRIPTION
As a result of apache 2.4 the run-time configuration is different to apache 2.2 (https://httpd.apache.org/docs/2.4/upgrading.html) - Changes should make htaccess to work as expected in both versions.
or – Is there maybe a better way?