### PR TITLE
Allow setting TinyMCE4 "Custom Style Formats" fully manually

### DIFF
--- a/assets/lib/class.modxRTEbridge.php
+++ b/assets/lib/class.modxRTEbridge.php
@@ -365,7 +365,7 @@ class modxRTEbridge
             if ($value === NULL) { continue; }; // Skip none-allowed empty settings
 
             // Escape quotes
-            if (!is_array($value) && strpos($value, "'") !== false && $conf['type'] != 'raw')
+            if (!is_array($value) && strpos($value, "'") !== false && !in_array($conf['type'], array('raw','object','obj')) )
                 $value = str_replace("'", "\\'", $value);
 
             // Determine output-type

--- a/assets/plugins/tinymce4/bridge.tinymce4.inc.php
+++ b/assets/plugins/tinymce4/bridge.tinymce4.inc.php
@@ -98,25 +98,32 @@ class tinymce4bridge extends modxRTEbridge
 
     // https://www.tinymce.com/docs/configure/content-formatting/#style_formats
     public function bridge_style_formats($selector) {
-        $sfArray[] = array('title' => 'Paragraph', 'format' => 'p');
-        $sfArray[] = array('title' => 'Header 1', 'format' => 'h1');
-        $sfArray[] = array('title' => 'Header 2', 'format' => 'h2');
-        $sfArray[] = array('title' => 'Header 3', 'format' => 'h3');
-        $sfArray[] = array('title' => 'Header 4', 'format' => 'h4');
-        $sfArray[] = array('title' => 'Header 5', 'format' => 'h5');
-        $sfArray[] = array('title' => 'Header 6', 'format' => 'h6');
-        $sfArray[] = array('title' => 'Div', 'format' => 'div');
-        $sfArray[] = array('title' => 'Pre', 'format' => 'pre');
+        // Set in plugin-configuration
+        if (isset($this->pluginParams['styleFormats']) && !empty($this->pluginParams['styleFormats'])) {
+            // Check for simple format: Title,cssClass|Title2,cssClass
+            if(preg_match('/^[a-zA-Z0-9,]+/', $this->pluginParams['styleFormats'])) {
+                $sfArray[] = array('title' => 'Paragraph', 'format' => 'p');
+                $sfArray[] = array('title' => 'Header 1', 'format' => 'h1');
+                $sfArray[] = array('title' => 'Header 2', 'format' => 'h2');
+                $sfArray[] = array('title' => 'Header 3', 'format' => 'h3');
+                $sfArray[] = array('title' => 'Header 4', 'format' => 'h4');
+                $sfArray[] = array('title' => 'Header 5', 'format' => 'h5');
+                $sfArray[] = array('title' => 'Header 6', 'format' => 'h6');
+                $sfArray[] = array('title' => 'Div', 'format' => 'div');
+                $sfArray[] = array('title' => 'Pre', 'format' => 'pre');
 
-        // Set in plugin-configuration, format: Title,cssClass|Title2,cssClass
-        if (isset($this->pluginParams['styleFormats'])) {
-            $styles_formats = explode('|', $this->pluginParams['styleFormats']);
-            foreach ($styles_formats as $val) {
-                $style = explode(',', $val);
-                $sfArray[] = array('title' => $style['0'], 'selector' => 'a,strong,em,p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,tr,span,img', 'classes' => $style['1']);
+                $styles_formats = explode('|', $this->pluginParams['styleFormats']);
+                foreach ($styles_formats as $val) {
+                    $style = explode(',', $val);
+                    $sfArray[] = array('title' => $style['0'], 'selector' => 'a,strong,em,p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,tr,span,img', 'classes' => $style['1']);
+                }
+                return $sfArray;    // return NULL would avoid bridging this parameter
+            } else {
+                // Allow full-format as seen in https://www.tinymce.com/docs/demo/format-custom/
+                $this->set('style_formats', $this->pluginParams['styleFormats'], 'object');
             }
         }
-        return $sfArray;    // return NULL would avoid bridging this parameter
+        return NULL;
     }
 
     // https://www.tinymce.com/docs/configure/editor-appearance/#resize

--- a/assets/plugins/tinymce4/plugin.tinymce.php
+++ b/assets/plugins/tinymce4/plugin.tinymce.php
@@ -17,7 +17,7 @@
  * @documentation Plugin docs https://github.com/extras-evolution/tinymce4-for-modx-evo
  * @documentation Official TinyMCE4-docs https://www.tinymce.com/docs/
  * @author      Deesen
- * @lastupdate  2016-10-06
+ * @lastupdate  2016-11-01
  */
 if (!defined('MODX_BASE_PATH')) { die('What are you doing? Get out of here!'); }
 

--- a/manager/actions/mutate_module.dynamic.php
+++ b/manager/actions/mutate_module.dynamic.php
@@ -233,7 +233,7 @@ function showParameters(ctrl) {
                         }
                         break;
                     case 'textarea':
-                        c = '<textarea name="prop_' + key + '" style="width:98%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
+                        c = '<textarea name="prop_' + key + '" style="width:80%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
                         break;
                     default:  // string
                         c = '<input type="text" name="prop_' + key + '" value="' + value + '" style="width:80%" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)" />';

--- a/manager/actions/mutate_plugin.dynamic.php
+++ b/manager/actions/mutate_plugin.dynamic.php
@@ -219,7 +219,7 @@ function showParameters(ctrl) {
                         }
                         break;
                     case 'textarea':
-                        c = '<textarea name="prop_' + key + '" style="width:98%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
+                        c = '<textarea name="prop_' + key + '" style="width:80%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
                         break;
                     default:  // string
                         c = '<input type="text" name="prop_' + key + '" value="' + value + '" style="width:80%" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)" />';

--- a/manager/actions/mutate_snippet.dynamic.php
+++ b/manager/actions/mutate_snippet.dynamic.php
@@ -221,10 +221,10 @@ function showParameters(ctrl) {
                         }
                         break;
                     case 'textarea':
-                        c = '<textarea name="prop_' + key + '" style="width:98%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
+                        c = '<textarea name="prop_' + key + '" style="width:80%" rows="4" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)">' + value + '</textarea>';
                         break;
                     default:  // string
-                        c = '<input type="text" name="prop_' + key + '" value="' + value + '" style="width:98%" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)" />';
+                        c = '<input type="text" name="prop_' + key + '" value="' + value + '" style="width:80%" onchange="setParameter(\'' + key + '\',\'' + type + '\',this)" />';
                         break;
                 }
 


### PR DESCRIPTION
Ref. to #886 allow setting Custom Style Format in TinyMCE4 like in demo https://www.tinymce.com/docs/demo/format-custom/

TinyMCE4-configuration :

![custom_styles](https://cloud.githubusercontent.com/assets/8569221/19882314/faaf393c-a00c-11e6-8b71-ac97fe6edbd3.png)

Example-String from demo

    [
      { title: 'Bold text', inline: 'strong' },
      { title: 'Red text', inline: 'span', styles: { color: '#ff0000' } },
      { title: 'Red header', block: 'h1', styles: { color: '#ff0000' } },
      { title: 'Badge', inline: 'span', styles: { display: 'inline-block', border: '1px solid #2276d2', 'border-radius': '5px', padding: '2px 5px', margin: '0 2px', color: '#2276d2' } },
      { title: 'Table row 1', selector: 'tr', classes: 'tablerow1' }
    ]

Parameter **still accepts simple format** like before: `Title,cssClass|Title2,cssClass`

---------------------------

Small fix: In configurations textarea has now same width as inputs

![no-overlap](https://cloud.githubusercontent.com/assets/8569221/19882376/98a39886-a00d-11e6-8045-63a1cff1dc5c.png)


