### PR TITLE
Include escaped brackets when sanitizing values

### DIFF
--- a/manager/includes/protect.inc.php
+++ b/manager/includes/protect.inc.php
@@ -38,17 +38,17 @@ if (!function_exists('modx_sanitize_gpc')) {
             }
         }
         else $values = getSanitizedValue($values);
-        
+
         return $values;
     }
 }
 
 function getSanitizedValue($value='') {
     global $sanitize_seed;
-    
+
     if(!$value) return $value;
-    
-    $brackets = explode(' ', '[[ ]] [! !] [* *] [( )] {{ }} [+ +] [~ ~] [^ ^]');
+
+    $brackets = explode(' ', '[[ ]] [! !] [* *] [( )] {{ }} [+ +] [~ ~] [^ ^] \[\[ \]\] \{\{ \}\} \[\( \)\] \[\~ \~\] \[\+ \+\] \[\* \*\] \[! !\] [\[ ]\] {\{ }\} [\( )\] [\~ ~\] [\+ +\] [\* *\] [\! !\]');
     foreach($brackets as $bracket) {
         if(strpos($value,$bracket)===false) continue;
         $sanitizedBracket = str_replace('#', $sanitize_seed, sprintf('#%s#%s#', substr($bracket,0,1), substr($bracket,1,1)));


### PR DESCRIPTION
Improves security by further sanitizing user input against potential MODX tags using escaped bracket patterns, especially sites v1.0.10+ relying on eForm since #154 was merged.