### PR TITLE
Update qm.inc.php

### DIFF
--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -950,7 +950,7 @@ class Qm {
 
 		$result = $this->modx->db->select('count(internalKey)', $activeUsersTable, "(action = 27) AND internalKey != '{$userId}' AND `id` = '{$pageId}'");
 
-		if ($this->modx->db->getValue($result) === 0) {
+		if ($this->modx->db->getValue($result) === '0') {
 			$locked = FALSE;
 		}
 


### PR DESCRIPTION
Fix comparison so Quick Manager+ inline tv editing does not always indicate the tv is locked.