### PR TITLE
Dashboard: Limit deleting localStorage to grid-items only

### DIFF
--- a/manager/media/style/MODxRE2/welcome.tpl
+++ b/manager/media/style/MODxRE2/welcome.tpl
@@ -166,9 +166,10 @@
 </script>
 
 <script type="text/javascript">        
-  function cleanLocalStorage() {
-    for(key in localStorage) {
-      delete localStorage[key];
+  function cleanLocalStorage(keys) {
+    keys = keys.split(',');
+    for (var i = 0; i < keys.length; i++) {
+      delete localStorage[keys[i]];
     }
     location.reload();
   }


### PR DESCRIPTION
Codemirror etc uses also localStorage-items and we do not want to kill complete localStorage.