### PR TITLE
Fixing a suddenly occuring thousands separator

### DIFF
--- a/assets/snippets/eform/eform.inc.php
+++ b/assets/snippets/eform/eform.inc.php
@@ -332,7 +332,7 @@ function eForm($modx,$params) {
 					switch ($datatype)  {
 
 						case "integer":
-							$value = number_format( (float) $value);	//EM~
+							$value = number_format((float) $value, 0, '.', '');
 							break;
 						case "float":
 							$localeInfo = localeconv();


### PR DESCRIPTION
Maybe the locale info was changed during a PHP or system update. It makes no sense to have an integer formatted with a thousands separator. The code could be maybe changed into `intval($value)` - should be the same.