### PR TITLE
Small fixes

### DIFF
--- a/install/assets/plugins/tinymce4.tpl
+++ b/install/assets/plugins/tinymce4.tpl
@@ -10,7 +10,6 @@
  * @internal    @properties &styleFormats=Custom Style Formats;textarea;Title,cssClass|Title2,cssClass &customParams=Custom Parameters <b>(Be careful or leave empty!)</b>;textarea; &entityEncoding=Entity Encoding;list;named,numeric,raw;named &entities=Entities;text; &pathOptions=Path Options;list;Site config,Absolute path,Root relative,URL,No convert;Site config &resizing=Advanced Resizing;list;true,false;false &disabledButtons=Disabled Buttons;text; &webTheme=Web Theme;test;webuser &webPlugins=Web Plugins;text; &webButtons1=Web Buttons 1;text;bold italic underline strikethrough removeformat alignleft aligncenter alignright &webButtons2=Web Buttons 2;text;link unlink image undo redo &webButtons3=Web Buttons 3;text; &webButtons4=Web Buttons 4;text; &webAlign=Web Toolbar Alignment;list;ltr,rtl;ltr &width=Width;text;100% &height=Height;text;400px &introtextRte=<b>Introtext RTE</b><br/>add richtext-features to "introtext";list;enabled,disabled;disabled &inlineMode=<b>Inline-Mode</b>;list;enabled,disabled;disabled &inlineTheme=<b>Inline-Mode</b><br/>Theme;text;inline
  * @internal    @events OnLoadWebDocument,OnParseDocument,OnWebPagePrerender,OnLoadWebPageCache,OnRichTextEditorRegister,OnRichTextEditorInit,OnInterfaceSettingsRender
  * @internal    @modx_category Manager and Admin
- * @internal    @legacy_names TinyMCE4
  * @internal    @installset base
  * @logo        /assets/plugins/tinymce4/tinymce/logo.png
  * @reportissues https://github.com/extras-evolution/tinymce4-for-modx-evo

--- a/install/setup.info.php
+++ b/install/setup.info.php
@@ -171,7 +171,7 @@ if(is_dir($modulePath) && is_readable($modulePath)) {
             );
         }
 		if (intval($params['shareparams']) || !empty($params['dependencies'])) {
-			$dependencies = explode(',', $dependencies);
+			$dependencies = explode(',', $params['dependencies']);
 			foreach ($dependencies as $dependency) {
 				$dependency = explode(':', $dependency);
 				switch (trim($dependency[0])) {

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3357,7 +3357,7 @@ class DocumentParser {
             $where = sprintf("`name`='%s'", $this->db->escape($chunkName));
             $rs= $this->db->select('snippet', $this->getFullTableName('site_htmlsnippets'), $where);
             if ($this->db->getRecordCount($rs)==1) {
-                $row= $this->db->getRow($result);
+                $row= $this->db->getRow($rs);
                 $out = $this->chunkCache[$chunkName]= $row['snippet'];
             }
             else $out = $this->chunkCache[$chunkName] = null;
@@ -4720,7 +4720,7 @@ class DocumentParser {
     function cleanUpMODXTags($content='') {
         global $sanitize_seed;
         
-        if(strpos($string,$sanitize_seed)!==false) $content = str_replace($sanitize_seed, '', $content);
+        if(strpos($sanitize_seed,$content)!==false) $content = str_replace($sanitize_seed, '', $content);
         
         $enable_filter = $this->config['enable_filter'];
         $this->config['enable_filter'] = 1;


### PR DESCRIPTION
Not sure if removing `@internal @legacy_names TinyMCE4` makes 100% sense. But if not Tiny4 is always disabled when I run upgrade on an existing installation.

Dependencies: https://github.com/modxcms/evolution/issues/990#issuecomment-263302520