### PR TITLE
Fixed input height

### DIFF
--- a/assets/plugins/managermanager/widgets/ddmultiplefields/ddmultiplefields.css
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/ddmultiplefields.css
@@ -17,7 +17,7 @@
 	font: 12px/1.2em Verdana,Helvetica,sans-serif !important;
 }
 
-.ddMultipleField input {height: 1.2em;}
+.ddMultipleField input {height: 2em;}
 
 .ddMultipleField input:focus {border-color: #E1A020 !important;}
 


### PR DESCRIPTION
Since widget was designed in content-box model, input height is very small and overflowing in border-box which used in new manager theme