### PR TITLE
Update duplicate_content.processor.php

### DIFF
--- a/manager/processors/duplicate_content.processor.php
+++ b/manager/processors/duplicate_content.processor.php
@@ -64,7 +64,7 @@ function duplicateDocument($docid, $parent=null, $_toplevel=0) {
 		if($count>=1) $count = ' '.($count+1);
 		else $count = '';
 		
-		$content['pagetitle'] = $content['pagetitle'].' '.$_lang['duplicated_el_suffix'].$count;
+		$content['pagetitle'] = $_lang['duplicated_el_suffix'].$count.' '.$content['pagetitle'];
 		$content['alias'] = null;
 	} elseif($modx->config['friendly_urls'] == 0 || $modx->config['allow_duplicate_alias'] == 0) {
 		$content['alias'] = null;


### PR DESCRIPTION
"Duplicated" must be first a pagetitle.
Do not touch this, heretics!

During content creation is the most important changes to be seen first and foremost.
Therefore, the word "Duplicated" to be returned to the beginning of the line "pagetitle". 
This reduces the time to edit new page after "Create copy".

