### PR TITLE
[I] changing output filename for easier sorting

### DIFF
--- a/assets/snippets/phpthumb/snippet.phpthumb.php
+++ b/assets/snippets/phpthumb/snippet.phpthumb.php
@@ -62,10 +62,11 @@ foreach ($tmpImagesFolder as $folder) {
         }
     }
 }
-  
-$fname_preffix=$cacheFolder."/".$params['w']."x".$params['h'].'-';
-$fname = $path_parts['filename'].".".substr(md5(serialize($params).filemtime(MODX_BASE_PATH . $input)),0,3).".".$params['f'];
-$outputFilename =MODX_BASE_PATH.$fname_preffix.$fname;
+
+$fname_preffix = "$cacheFolder/";
+$fname = $path_parts['filename'];
+$fname_suffix = "-{$params['w']}x{$params['h']}-".substr(md5(serialize($params).filemtime(MODX_BASE_PATH . $input)),0,3).".{$params['f']}";
+$outputFilename = MODX_BASE_PATH.$fname_preffix.$fname.$fname_suffix;
 if (!file_exists($outputFilename)) {
     require_once MODX_BASE_PATH.'assets/snippets/phpthumb/phpthumb.class.php';
     $phpThumb = new phpthumb();
@@ -81,5 +82,5 @@ if (!file_exists($outputFilename)) {
         $modx->logEvent(0, 3, implode('<br/>', $phpThumb->debugmessages), 'phpthumb');
     }
 }
-return $fname_preffix.rawurlencode($fname);
+return $fname_preffix.rawurlencode($fname).$fname_suffix;
 ?>


### PR DESCRIPTION
Hi there,

maybe it's just me, but when developing a site I sometimes need to delete the cached images from phpthumb. But when there are several images in different sizes of on image, it's awful to select them from a list sorted by filename.
So instead of the current output filename `1200x1200-filename-123.jpg` I propose to generate it like this `filename-1200x1200-1234.jpg` where `1234` is the hash. Then all generated files are directly one below the other.