### PR TITLE
Function isn't a constructor, it's a static method

### DIFF
--- a/assets/snippets/phpthumb/phpthumb.unsharp.php
+++ b/assets/snippets/phpthumb/phpthumb.unsharp.php
@@ -43,7 +43,7 @@ and the roundoff errors in the Gaussian blur process, are welcome.
 
 class phpUnsharpMask {
 
-	static function __construct(&$img, $amount, $radius, $threshold) {
+	static function applyUnsharpMask(&$img, $amount, $radius, $threshold) {
 
 		// $img is an image that is already created within php using
 		// imgcreatetruecolor. No url! $img must be a truecolor image.


### PR DESCRIPTION
This is breaking our sites. This is present in 1.2.1 and prevented pages from being rendered properly. Please also note that contructors can't be static