### PR TITLE
[I] Check for sess_deleted

### DIFF
--- a/install/config.inc.tpl
+++ b/install/config.inc.tpl
@@ -87,7 +87,7 @@ if(!function_exists('startCMSSession')) {
     $site_sessionname = 'evo' . $_;
     
     function removeInvalidCmsSessionFromStorage(&$storage, $session_name) {
-      if (isset($storage[$session_name]) && $storage[$session_name] === '')
+      if (isset($storage[$session_name]) && ($storage[$session_name] === '' || $storage[$session_name] === 'deleted'))
       {
         unset($storage[$session_name]);
       }


### PR DESCRIPTION
Some browsers can return 'deleted' as a session after logging out which in turn can result in sharing 'sess_deleted' session file.
So check for 'deleted' as well as ''.

see here for example: https://bugs.php.net/bug.php?id=38260