### PR TITLE
[F] fix css typo in manage elements styles

### DIFF
--- a/manager/media/style/MODxRE2/style.css
+++ b/manager/media/style/MODxRE2/style.css
@@ -3276,7 +3276,7 @@ ul.elements_buttonbar .fa {font-size: 13px!important; padding:1px 1px 0; }
 .switchForm .optionsFontsSize {margin-left:9px;padding-left:8px;border-left:1px solid #ededed;}
 .switchForm .optionsReset {margin-left:8px;border-left:1px solid #ededed;padding-left:8px;}
 .switchForm .optionsAllTabs {clear:left;padding-top:10px;}
-.switchForm .optionsClear {display:block;clear: both; padding-top:8px;margin-bottom:4px;border-bottom: 1px solid #ededed;}}
+.switchForm .optionsClear {display:block;clear: both; padding-top:8px;margin-bottom:4px;border-bottom: 1px solid #ededed;}
 
 /* Checkbox "Icons" */
 .noicons.tab-page ul li ul li a:before,


### PR DESCRIPTION
Fix a small css typo (double bracket) that cause issue with show/ hide icons checkbox in
manage elements view option