### PR TITLE
Icon for first tab

### DIFF
--- a/install/assets/plugins/ElementsInTree.tpl
+++ b/install/assets/plugins/ElementsInTree.tpl
@@ -7,7 +7,7 @@
  * @category    plugin
  * @version     1.5.7
  * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU Public License (GPL v2)
- * @internal    @properties &tabTreeTitle=Tree Tab Title;text;Site Tree;;Custom title of Site Tree tab. &useIcons=Use icons in tabs;list;yes,no;yes;;Icons available in MODX version 1.2 or newer. &treeButtonsInTab=Tree Buttons in tab;list;yes,no;yes;;Move Tree Buttons into Site Tree tab. &unifyFrames=Unify Frames;list;yes,no;yes;;Unify Tree and Main frame style. Right now supports MODxRE2 theme only.
+ * @internal    @properties &tabTreeTitle=Tree Tab Title;text;<i class='fa fa-sitemap'></i>;;Custom title of Site Tree tab. &useIcons=Use icons in tabs;list;yes,no;yes;;Icons available in MODX version 1.2 or newer. &treeButtonsInTab=Tree Buttons in tab;list;yes,no;yes;;Move Tree Buttons into Site Tree tab. &unifyFrames=Unify Frames;list;yes,no;yes;;Unify Tree and Main frame style. Right now supports MODxRE2 theme only.
  * @internal    @events OnManagerTreePrerender,OnManagerTreeRender,OnManagerMainFrameHeaderHTMLBlock,OnTempFormSave,OnTVFormSave,OnChunkFormSave,OnSnipFormSave,OnPluginFormSave,OnModFormSave,OnTempFormDelete,OnTVFormDelete,OnChunkFormDelete,OnSnipFormDelete,OnPluginFormDelete,OnModFormDelete
  * @internal    @modx_category Manager and Admin
  * @internal    @installset base


### PR DESCRIPTION
I propose to use sitemap icon instead of "Site Tree" words because this is only one text label by default.
Or maybe move icon to plugin content and show by default if Tree Tab Title is empty