### PR TITLE
fixed wrong path to jquery library

### DIFF
--- a/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/template.html
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/template.html
@@ -6,7 +6,7 @@
 	<title>Tiny MCE</title>
 	<link rel="stylesheet" type="text/css" href="[+style+]" />
 	<link rel="stylesheet" type="text/css" href="[+windowDir+]style.css" />
-	<script type="text/javascript" src="[+mmDir+]js/jquery.min.js"></script>
+	<script type="text/javascript" src="[+mmDir+]js/jquery-1.9.1.min.js"></script>
 	<script type="text/javascript" src="[+windowDir+]script.js"></script>
 	[+tinyMCE+]
 </head>


### PR DESCRIPTION
There is no jquery.min.js in /assets/plugins/managermanager/js/ so widget is not working and editing richtext field in a row is impossible due to $(function) is not defined with incorrect path to jquery