### PR TITLE
fix sendForward method

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -248,7 +248,6 @@ class DocumentParser {
             $this->forwards= $this->forwards - 1;
             $this->documentIdentifier= $id;
             $this->documentMethod= 'id';
-            $this->documentObject= $this->getDocumentObject('id', $id);
             if ($responseCode) {
                 header($responseCode);
             }


### PR DESCRIPTION
getDocumentObject is called in prepareResponse, there's no need  to call it here (https://github.com/dmi3yy/modx.evo.custom/issues/340).