### PR TITLE
MM richtext popup corrects

### DIFF
--- a/assets/plugins/managermanager/widgets/ddmultiplefields/jquery.ddMM.mm_ddMultipleFields.js
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/jquery.ddMM.mm_ddMultipleFields.js
@@ -541,10 +541,10 @@ $.ddMM.mm_ddMultipleFields = {
 		
 		$('<div class="ddFieldCol_edit"><a class="false" href="#">' + $.ddMM.lang.edit + '</a></div>').appendTo($fieldCol).find('a').on('click', function(event){
 			_this.richtextWindow = window.open($.ddMM.config.site_url + $.ddMM.urls.mm + 'widgets/ddmultiplefields/richtext/index.php', 'mm_ddMultipleFields_richtext', new Array(
-				'width=600',
-				'height=550',
-				'left=' + (($.ddTools.windowWidth - 600) / 2),
-				'top=' + (($.ddTools.windowHeight - 550) / 2),
+				'width=700',
+				'height=600',
+				'left=' + (($.ddTools.windowWidth - 700) / 2),
+				'top=' + (($.ddTools.windowHeight - 600) / 2),
 				'menubar=no',
 				'toolbar=no',
 				'location=no',

--- a/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/script.js
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/script.js
@@ -1,15 +1,17 @@
 $(function(){
 	var $textarea = $('#ddMultipleFields_richtext');
-	
+
 	$textarea.val(window.$ddField.html()).trigger('change');
-	
+
 	$('.js-ok').on('click', function(){
-		tinyMCE.triggerSave();
+		if (typeof tinyMCE != 'undefined') {
+			tinyMCE.triggerSave();
+		}
 		window.$ddField.html($textarea.val());
 		$textarea.val('');
 		window.close();
 	});
-	
+
 	$('.js-cancel').on('click', function(){
 		$textarea.val('');
 		window.close();

--- a/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/style.css
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/style.css
@@ -1,3 +1,8 @@
+textarea {
+	width: 100%;
+	min-height: 250px;
+	box-sizing: border-box;
+}
 .buttons {
 	padding-top: 10px;
 	text-align: right;

--- a/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/style.css
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/style.css
@@ -1,9 +1,16 @@
+html, body {
+	height: 100%;
+}
 textarea {
 	width: 100%;
 	min-height: 250px;
 	box-sizing: border-box;
+	height: calc( 100% - 45px );
 }
 .buttons {
 	padding-top: 10px;
 	text-align: right;
+}
+body > .mce-container {
+	box-sizing: border-box;
 }

--- a/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/template.html
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/richtext/template.html
@@ -11,7 +11,7 @@
 	[+tinyMCE+]
 </head>
 <body>
-	<textarea id="ddMultipleFields_richtext"></textarea>
+	<textarea id="ddMultipleFields_richtext" autofocus="autofocus"></textarea>
 	<div class="buttons">
 		<button class="js-ok">Ok</button><button class="js-cancel">Cancel</button>
 	</div>


### PR DESCRIPTION
Rich text field in popup window is now working correctly without TinyMCE.
No scrolls in Rich text field popup window. Correct window and element sizes. Textarea autofocus.