### PR TITLE
[F] prevent multiple drop events in KCFinder

### DIFF
--- a/manager/media/browser/mcpuk/js/browser/dropUpload.js
+++ b/manager/media/browser/mcpuk/js/browser/dropUpload.js
@@ -94,15 +94,34 @@ browser.initDropUpload = function() {
         return false;
     };
 
-    files.get(0).removeEventListener('dragover', filesDragOver, false);
-    files.get(0).removeEventListener('dragenter', filesDragEnter, false);
-    files.get(0).removeEventListener('dragleave', filesDragLeave, false);
-    files.get(0).removeEventListener('drop', filesDrop, false);
+    var handlers = files.data( 'handlers' );
+
+    if ( handlers ) {
+        if ( handlers.dragover ) {
+            files.get(0).removeEventListener('dragover', handlers.dragover, false);
+        }
+        if ( handlers.dragenter ) {
+            files.get(0).removeEventListener('dragenter', handlers.dragenter, false);
+        }
+        if ( handlers.dragleave ) {
+            files.get(0).removeEventListener('dragleave', handlers.dragleave, false);
+        }
+        if ( handlers.drop ) {
+            files.get(0).removeEventListener('drop', handlers.drop, false);
+        }
+    }
 
     files.get(0).addEventListener('dragover', filesDragOver, false);
     files.get(0).addEventListener('dragenter', filesDragEnter, false);
     files.get(0).addEventListener('dragleave', filesDragLeave, false);
     files.get(0).addEventListener('drop', filesDrop, false);
+
+    files.data( 'handlers', {
+        dragover:  filesDragOver,
+        dragenter: filesDragEnter,
+        dragleave: filesDragLeave,
+        drop:      filesDrop
+    } );
 
     folders.each(function() {
         var folder = this,


### PR DESCRIPTION
When creating new folder and then trying to upload, the files start to be uploading several times, with names ...(1), ...(2) and so on.
This is because uncorrect removing listener of drop event - every time we try to remove new function, which just declared.