### PR TITLE
[F] thumb generation fixed on some php7 systems

### DIFF
--- a/manager/media/browser/mcpuk/core/uploader.php
+++ b/manager/media/browser/mcpuk/core/uploader.php
@@ -688,7 +688,7 @@ class uploader {
             $tile   = image::factory( $this->imageDriver, __DIR__ . '/../themes/' . $this->config['theme'] . '/img/bg_transparent.png' );
             
             imagesettile( $back->image, $tile->image );
-            imagefill( $back->image, 0, 0, IMG_COLOR_TILED );
+            imagefilledrectangle( $back->image, 0, 0, $width, $height, IMG_COLOR_TILED );
             imagecopy( $back->image, $img->image, 0, 0, 0, 0, $width, $height );
 
             $img = $back;


### PR DESCRIPTION
On some machines with php7 installed, simple thumb generation causes apache memory error that cannot be catched by "try-catch" construction.
In interface this is shows as "Unknown error" in panels, when attempting opening filemanager.