### PR TITLE
fix syntax error, unexpected ';' in (1267)

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1273,7 +1273,7 @@ class DocumentParser {
                 $cmd = rtrim($cmd,'-');
                 $cmd = trim($cmd);
                 $cmd = str_ireplace(array(' and ',' or '),array('&&','||'),$cmd);
-                
+                $cmd = trim($cmd,'|');
                 if($cmd!=='' && !preg_match('@^[0-9]*$@', $cmd) && preg_match('@^[0-9<= \-\+\*/\(\)%!&|]*$@', $cmd))
                     $cmd = (int) eval("return {$cmd};");
                 if($cmd < 0) $cmd = 0;


### PR DESCRIPTION
Профилю Editor разрешено запускать только один модуль.
В данной ситуации ломается админка.

![evo cms manager](https://user-images.githubusercontent.com/8142648/31340578-ab3e1850-ad17-11e7-8783-33c104677209.png)
